### PR TITLE
Added optional scope modules skeletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ See specifically [this issue comment](https://github.com/DefinitelyTyped/Definit
 
 ## Module-Level Status
 
+* [D3 Standard Bundle Modules](#d3-standard-bundle-modules)
+* [Optional Scope Modules](#optional-scope-modules)
+
 First of: 
 
 * As long as a D3 module does not have a definition _and_ test file flagged as complete, the definition is available for review and comment, but not considered stable. Self-evidently, changes may also result from changes to D3 itself. 
@@ -348,6 +351,20 @@ _Migration in progress. Check [here](https://github.com/tomwanzek/d3-v4-definite
 _Note_: Utilizes `this`-typing (criticality: _high_)
 
 `this`-typing is used for context-binding to DOM element.
+
+### Optional Scope Modules
+
+_(in alphabetical order)_
+
+#### d3-scale-chromatic
+
+- [ ] Definition File
+- [ ] Test File
+
+#### d3-selection-multi
+
+- [ ] Definition File
+- [ ] Test File
 
 
 ## Contributing

--- a/src/d3-scale-chromatic/index.d.ts
+++ b/src/d3-scale-chromatic/index.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for D3JS d3-scale-chromatic module 1.0.1
+// Project: https://github.com/d3/d3-scale-chromatic/
+// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/src/d3-scale-chromatic/typings.json
+++ b/src/d3-scale-chromatic/typings.json
@@ -1,0 +1,14 @@
+{
+  "name": "d3-scale-chromatic",
+  "homepage": "https://github.com/d3/d3-scale-chromatic",
+  "version": "1.0.1",
+  "global": false,
+  "main": "index.d.ts",
+  "files": [
+    "index.d.ts"
+  ],
+  "dependencies": {
+    
+  },
+  "globalDependencies": {}
+}

--- a/src/d3-selection-multi/index.d.ts
+++ b/src/d3-selection-multi/index.d.ts
@@ -1,0 +1,7 @@
+// Type definitions for D3JS d3-selection-multi module 0.4.1
+// Project: https://github.com/d3/d3-selection-multi/
+// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import {Selection} from '../d3-selection';
+import {Transition} from '../d3-transition';

--- a/src/d3-selection-multi/typings.json
+++ b/src/d3-selection-multi/typings.json
@@ -1,0 +1,14 @@
+{
+  "name": "d3-selection-multi",
+  "homepage": "https://github.com/d3/d3-selection-multi",
+  "version": "0.4.1",
+  "global": false,
+  "main": "index.d.ts",
+  "files": [
+    "index.d.ts"
+  ],
+  "dependencies": {
+    
+  },
+  "globalDependencies": {}
+}

--- a/tests/d3-scale-chromatic/d3-scale-chromatic-test.ts
+++ b/tests/d3-scale-chromatic/d3-scale-chromatic-test.ts
@@ -1,0 +1,10 @@
+/**
+ * Typescript definition tests for d3/d3-scale-chromatic module
+ * 
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
+
+// TODO: uncomment below and add tests
+// import * as d3ScaleChromatic from '../../src/d3-scale-chromatic';

--- a/tests/d3-selection-multi/d3-selection-multi-test.ts
+++ b/tests/d3-selection-multi/d3-selection-multi-test.ts
@@ -1,0 +1,15 @@
+
+/**
+ * Typescript definition tests for d3/d3-selection-multi module
+ * 
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
+
+import {Selection} from '../../src/d3-selection';
+import {Transition} from '../../src/d3-transition';
+
+import * as d3SelectionMulti from '../../src/d3-selection-multi';
+
+// Add tests of augmentation


### PR DESCRIPTION
- Added folders and starting templates for optional scope modules (d3-scale-chromatic and d3-selection-multi)
- Added subsection to README
