### PR TITLE
d3-force (complete):

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ _Migration in progress. Check [here](https://github.com/tomwanzek/d3-v4-definite
 
 #### d3-force
 
-- [x] [Definition File](https://github.com/tomwanzek/d3-v4-definitelytyped/blob/master/src/d3-force/index.d.ts) (*draft*)
-- [ ] [Test File](https://github.com/tomwanzek/d3-v4-definitelytyped/blob/master/tests/d3-ease/d3-ease-test.ts)
+- [x] [Definition File](https://github.com/tomwanzek/d3-v4-definitelytyped/blob/master/src/d3-force/index.d.ts)
+- [x] [Test File](https://github.com/tomwanzek/d3-v4-definitelytyped/blob/master/tests/d3-ease/d3-ease-test.ts)
 
 _Note_: Utilizes `this`-typing (criticality: _medium_)
 

--- a/src/d3-force/index.d.ts
+++ b/src/d3-force/index.d.ts
@@ -46,7 +46,8 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
     alphaTarget(target: number): Simulation<NodeDatum, LinkDatum>;
     velocityDecay(): number;
     velocityDecay(decay: number): Simulation<NodeDatum, LinkDatum>;
-    force(name: string): Force<NodeDatum, LinkDatum>;
+    force(name: string): Force<NodeDatum, LinkDatum>; // force names are arbitrary, so return type inference is not possible
+    force(name: string, force: null): Simulation<NodeDatum, LinkDatum>;
     force(name: string, force: Force<NodeDatum, LinkDatum>): Simulation<NodeDatum, LinkDatum>;
     find(x: number, y: number, radius?: number): NodeDatum | undefined;
     on(typenames: 'tick' | 'end' | string): (this: Simulation<NodeDatum, LinkDatum>) => void;
@@ -84,7 +85,7 @@ export function forceCenter<NodeDatum extends SimulationNodeDatum>(x?: number, y
 export interface ForceCollide<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
     radius(): (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number;
     radius(radius: number): ForceCollide<NodeDatum>;
-    radius(radius: (node: NodeDatum, i?: number, nodes?: Array<NodeDatum>) => number): ForceCollide<NodeDatum>;
+    radius(radius: (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number): ForceCollide<NodeDatum>;
     strength(): number;
     strength(strength: number): ForceCollide<NodeDatum>;
     iterations(): number;
@@ -100,18 +101,20 @@ export function forceCollide<NodeDatum extends SimulationNodeDatum>(radius: (nod
 export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> extends Force<NodeDatum, LinkDatum> {
     links(): Array<LinkDatum>;
     links(links: Array<LinkDatum>): ForceLink<NodeDatum, LinkDatum>;
-    id(): (d: NodeDatum, i: number, nodesData: Array<NodeDatum>) => (string | number);
-    id(id: (d: NodeDatum, i?: number, nodesData?: Array<NodeDatum>) => string): ForceLink<NodeDatum, LinkDatum>;
-    distance(): (d: LinkDatum, i: number, linksData: Array<LinkDatum>) => number;
-    distance(distance: (d: LinkDatum, i: number, linksData: Array<LinkDatum>) => number): ForceLink<NodeDatum, LinkDatum>;
-    strength(): (d: LinkDatum, i: number, linksData: Array<LinkDatum>) => number;
-    strength(strength: (d: LinkDatum, i: number, linksData: Array<LinkDatum>) => number): ForceLink<NodeDatum, LinkDatum>;
+    id(): (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => (string | number);
+    id(id: (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => string): ForceLink<NodeDatum, LinkDatum>;
+    distance(): (link: LinkDatum, i: number, links: Array<LinkDatum>) => number;
+    distance(distance: number): ForceLink<NodeDatum, LinkDatum>;
+    distance(distance: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): ForceLink<NodeDatum, LinkDatum>;
+    strength(): (link: LinkDatum, i: number, links: Array<LinkDatum>) => number;
+    strength(strength: number): ForceLink<NodeDatum, LinkDatum>;
+    strength(strength: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): ForceLink<NodeDatum, LinkDatum>;
     iterations(): number;
     iterations(iterations: number): ForceLink<NodeDatum, LinkDatum>;
 }
 
 export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum extends SimulationLinkDatum<NodeDatum>>(): ForceLink<NodeDatum, LinksDatum>;
-export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum extends SimulationLinkDatum<NodeDatum>>(linksData: Array<LinksDatum>): ForceLink<NodeDatum, LinksDatum>;
+export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum extends SimulationLinkDatum<NodeDatum>>(links: Array<LinksDatum>): ForceLink<NodeDatum, LinksDatum>;
 
 // Many Body ----------------------------------------------------------------
 
@@ -131,28 +134,28 @@ export function forceManyBody<NodeDatum extends SimulationNodeDatum>(): ForceMan
 
 // Positioning ----------------------------------------------------------------
 
-export interface ForcePositionX<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
+export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
     strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
-    strength(strength: number): ForcePositionX<NodeDatum>;
-    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForcePositionX<NodeDatum>;
+    strength(strength: number): ForceX<NodeDatum>;
+    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceX<NodeDatum>;
     x(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
-    x(x: number): ForcePositionX<NodeDatum>;
-    x(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForcePositionX<NodeDatum>;
+    x(x: number): ForceX<NodeDatum>;
+    x(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceX<NodeDatum>;
 }
 
-export function forceX<NodeDatum extends SimulationNodeDatum>(): ForcePositionX<NodeDatum>;
-export function forceX<NodeDatum extends SimulationNodeDatum>(x: number): ForcePositionX<NodeDatum>;
-export function forceX<NodeDatum extends SimulationNodeDatum>(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForcePositionX<NodeDatum>;
+export function forceX<NodeDatum extends SimulationNodeDatum>(): ForceX<NodeDatum>;
+export function forceX<NodeDatum extends SimulationNodeDatum>(x: number): ForceX<NodeDatum>;
+export function forceX<NodeDatum extends SimulationNodeDatum>(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceX<NodeDatum>;
 
-export interface ForcePositionY<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
+export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
     strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
-    strength(strength: number): ForcePositionY<NodeDatum>;
-    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForcePositionY<NodeDatum>;
+    strength(strength: number): ForceY<NodeDatum>;
+    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceY<NodeDatum>;
     y(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
-    y(y: number): ForcePositionY<NodeDatum>;
-    y(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForcePositionY<NodeDatum>;
+    y(y: number): ForceY<NodeDatum>;
+    y(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceY<NodeDatum>;
 }
 
-export function forceY<NodeDatum extends SimulationNodeDatum>(): ForcePositionY<NodeDatum>;
-export function forceY<NodeDatum extends SimulationNodeDatum>(y: number): ForcePositionY<NodeDatum>;
-export function forceY<NodeDatum extends SimulationNodeDatum>(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForcePositionY<NodeDatum>;
+export function forceY<NodeDatum extends SimulationNodeDatum>(): ForceY<NodeDatum>;
+export function forceY<NodeDatum extends SimulationNodeDatum>(y: number): ForceY<NodeDatum>;
+export function forceY<NodeDatum extends SimulationNodeDatum>(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceY<NodeDatum>;

--- a/tests/d3-force/d3-force-test.ts
+++ b/tests/d3-force/d3-force-test.ts
@@ -1,126 +1,527 @@
-// /**
-//  * Typescript definition tests for d3/d3-force module
-//  * 
-//  * Note: These tests are intended to test the definitions only
-//  * in the sense of typing and call signature consistency. They
-//  * are not intended as functional tests.
-//  */
-
-// import * as d3Select from '../../src/d3-selection';
-// import {
-//     forceCenter,
-//     ForceCenter,
-//     forceLink,
-//     ForceLink,
-//     forceManyBody,
-//     ForceManyBody,
-//     forceSimulation,
-//     Simulation,
-//     SimulationLinkDatum,
-//     SimulationNodeDatum
-// } from '../../src/d3-force';
-
-// import * as d3Drag from '../../src/d3-drag';
-
-// interface SimNode extends SimulationNodeDatum {
-//     id: string;
-//     group: number;
-
-// }
-
-// interface SimLink extends SimulationLinkDatum<SimNode> {
-//     value: number;
-// }
-
-// interface Graph {
-//     nodes: Array<SimNode>;
-//     links: Array<SimLink>;
-// }
+/**
+ * Typescript definition tests for d3/d3-force module
+ * 
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
 
 
-// let canvas = document.querySelector("canvas"),
-//     context = canvas.getContext("2d"),
-//     width = canvas.width,
-//     height = canvas.height;
+import * as d3Force from '../../src/d3-force';
 
-// let simulation = forceSimulation<SimNode, SimLink>()
-//     .force("link", forceLink().id(function (d) { return d.id; }))
-//     .force("charge", forceManyBody())
-//     .force("center", forceCenter(width / 2, height / 2));
+// -------------------------------------------------------------------------------------
+// Preparatory Steps
+// -------------------------------------------------------------------------------------
 
+interface SimNode extends d3Force.SimulationNodeDatum {
+    id: string;
+    group: number;
+    r: number;
+}
 
-// let graph: Graph = {
-//     nodes: [
-//         { "id": "Myriel", "group": 1 },
-//         { "id": "Napoleon", "group": 1 },
-//         { "id": "Mlle.Baptistine", "group": 1 },
-//         { "id": "Mme.Magloire", "group": 1 },
-//         { "id": "CountessdeLo", "group": 1 }
-//     ],
-//     links: [
-//         { "source": "Napoleon", "target": "Myriel", "value": 1 },
-//         { "source": "Mlle.Baptistine", "target": "Myriel", "value": 8 },
-//         { "source": "Mme.Magloire", "target": "Myriel", "value": 10 },
-//         { "source": "Mme.Magloire", "target": "Mlle.Baptistine", "value": 6 }
-//     ]
-// };
+interface SimLink extends d3Force.SimulationLinkDatum<SimNode> {
+    value: number;
+    d: number;
+    s: number;
+}
+
+interface Graph {
+    nodes: Array<SimNode>;
+    links: Array<SimLink>;
+}
 
 
-// simulation
-//     .nodes(graph.nodes)
-//     .on("tick", function ticked() {
-//         context.clearRect(0, 0, width, height);
+let graph: Graph = {
+    nodes: [
+        { id: 'Myriel', group: 1, r: 5 },
+        { id: 'Napoleon', group: 1, r: 10 },
+        { id: 'Mlle.Baptistine', group: 1, r: 5 },
+        { id: 'Mme.Magloire', group: 1, r: 10 },
+        { id: 'CountessdeLo', group: 1, r: 5 }
+    ],
+    links: [
+        { source: 'Napoleon', target: 'Myriel', value: 1, d: 60, s: 0.95 },
+        { source: 'Mlle.Baptistine', target: 'Myriel', value: 8, d: 100, s: 0.85 },
+        { source: 'Mme.Magloire', target: 'Myriel', value: 10, d: 80, s: 0.85 },
+        { source: 'Mme.Magloire', target: 'Mlle.Baptistine', value: 6, d: 60, s: 0.95 }
+    ]
+};
 
-//         context.beginPath();
-//         graph.links.forEach(drawLink);
-//         context.strokeStyle = "#aaa";
-//         context.stroke();
+let simNode: SimNode;
+let simLink: SimLink;
 
-//         context.beginPath();
-//         graph.nodes.forEach(drawNode);
-//         context.fill();
-//         context.strokeStyle = "#fff";
-//         context.stroke();
-//     });
+let simNodes: Array<SimNode>;
+let simLinks: Array<SimLink>;
 
-// (<ForceLink<SimNode, SimLink>>simulation.force("link"))
-//     .links(graph.links);
+let num: Number;
 
-// d3Select.select(canvas)
-//     .call(d3Drag.drag()
-//         .container(canvas)
-//         .subject(dragsubject)
-//         .on("start", dragstarted)
-//         .on("drag", dragged)
-//         .on("end", dragended)
-//     );
+let canvas = document.querySelector('canvas'),
+    context = canvas.getContext('2d'),
+    width = canvas.width,
+    height = canvas.height;
+
+// -------------------------------------------------------------------------------------
+// Test Pre-Defined Forces
+// -------------------------------------------------------------------------------------
+
+// Centering ===========================================================================
+
+// create Centering force --------------------------------------------------------------
+
+let forceCenter: d3Force.ForceCenter<SimNode>;
+
+// without specified center point (i.e. defaults to [0, 0])
+forceCenter = d3Force.forceCenter<SimNode>();
+
+// with x-coordinate of center point
+forceCenter = d3Force.forceCenter<SimNode>(100);
+
+// with x- and y-coordinate of center point
+forceCenter = d3Force.forceCenter<SimNode>(100, 100);
+
+// Configure Centering force -----------------------------------------------------------
+
+forceCenter = forceCenter.x(150);
+num = forceCenter.x();
+
+forceCenter = forceCenter.y(150);
+num = forceCenter.y();
+
+// Use Centering force -----------------------------------------------------------------
+
+forceCenter.initialize(graph.nodes);
+forceCenter(0.1); // alpha
+
+// Collision ===========================================================================
+
+// create Collision force --------------------------------------------------------------
+
+let forceCollide: d3Force.ForceCollide<SimNode>;
+
+// without radius
+forceCollide = d3Force.forceCollide<SimNode>();
+
+// with fixed radius
+forceCollide = d3Force.forceCollide<SimNode>(15);
+
+// with radius accessor function
+forceCollide = d3Force.forceCollide<SimNode>(function (node, index, nodes) {
+    let n: SimNode = node;
+    let i: number = index;
+    let ns: Array<SimNode> = nodes;
+    return n.r;
+});
 
 
-// function dragsubject() {
-//     return simulation.find(d3Select.event.x, d3Select.event.y);
-// }
+// Configure Collision force -----------------------------------------------------------
+
+let radiusAccessor: (node: SimNode, i: number, nodes: Array<SimNode>) => number;
+
+// radius
+
+forceCollide = forceCollide.radius(20);
+forceCollide = forceCollide.radius(function (node, index, nodes) {
+    let n: SimNode = node;
+    let i: number = index;
+    let ns: Array<SimNode> = nodes;
+    return 2 * n.r;
+});
+
+radiusAccessor = forceCollide.radius();
+
+// strength
+
+forceCollide = forceCollide.strength(0.5);
+num = forceCollide.strength();
+
+// iterations
+
+forceCollide = forceCollide.iterations(10);
+num = forceCollide.iterations();
 
 
-// function dragstarted() {
-//     if (!d3Select.event.active) simulation.alphaTarget(0.3).restart()
-//     simulation.fix(d3.event.subject);
-// }
+// Use Collision force -----------------------------------------------------------------
 
-// function dragged() {
-//     simulation.fix(d3.event.subject, d3Select.event.x, d3Select.event.y);
-// }
+forceCollide.initialize(graph.nodes);
+forceCollide(0.1); // alpha
 
-// function dragended() {
-//     if (!d3Select.event.active) simulation.alphaTarget(0);
-//     simulation.unfix(d3Select.event.subject);
-// }
+// Link ================================================================================
 
-// function drawLink(d: SimLink) {
-//     context.moveTo(d.source.x, d.source.y);
-//     context.lineTo(d.target.x, d.target.y);
-// }
+// create Link force --------------------------------------------------------------
 
-// function drawNode(d: SimLink) {
-//     context.moveTo(d.x + 3, d.y);
-//     context.arc(d.x, d.y, 3, 0, 2 * Math.PI);
-// }
+let forceLink: d3Force.ForceLink<SimNode, SimLink>;
+
+// without link data
+forceLink = d3Force.forceLink<SimNode, SimLink>();
+
+// with link data
+forceLink = d3Force.forceLink<SimNode, SimLink>(graph.links);
+
+
+// Configure Link force -----------------------------------------------------------
+
+let linkNumberAccessor: (link: SimLink, i: number, links: Array<SimLink>) => number;
+let nodeIdAccessor: (node: SimNode, i: number, nodes: Array<SimNode>) => number | string;
+
+// links
+
+forceLink = forceLink.links(graph.links);
+
+simLinks = forceLink.links();
+
+simLink = simLinks[0];
+
+simNode = (typeof simLink.source !== 'number' && typeof simLink.source !== 'string') ? simLink.source : undefined;
+simNode = (typeof simLink.target !== 'number' && typeof simLink.target !== 'string') ? simLink.target : undefined;
+
+num = simLink.index;
+
+num = simLink.value;
+num = simLink.d;
+num = simLink.s;
+
+
+// id (node id accessor)
+
+forceLink = forceLink.id(function (node, index, nodes) {
+    let n: SimNode = node;
+    let i: number = index;
+    let ns: Array<SimNode> = nodes;
+    return n.id;
+});
+
+// distance
+
+forceLink = forceLink.distance(50);
+forceLink = forceLink.distance(function (link, index, links) {
+    let l: SimLink = link;
+    let i: number = index;
+    let ls: Array<SimLink> = links;
+    return l.d;
+});
+
+linkNumberAccessor = forceLink.distance();
+
+// strength
+
+forceLink = forceLink.strength(0.95);
+forceLink = forceLink.strength(function (link, index, links) {
+    let l: SimLink = link;
+    let i: number = index;
+    let ls: Array<SimLink> = links;
+    return l.s;
+});
+
+linkNumberAccessor = forceLink.strength();
+
+// iterations
+
+forceLink = forceLink.iterations(10);
+num = forceLink.iterations();
+
+
+// Use Link force -----------------------------------------------------------------
+
+forceLink.initialize(graph.nodes);
+forceLink(0.1); // alpha
+
+
+// ManyBody ============================================================================
+
+// create ManyBody force --------------------------------------------------------------
+
+let forceCharge: d3Force.ForceManyBody<SimNode>;
+
+forceCharge = d3Force.forceManyBody<SimNode>();
+
+// Configure ManyBody force -----------------------------------------------------------
+
+let simNodeNumberAccessor: (node: SimNode, i: number, nodes: Array<SimNode>) => number;
+
+// strength
+
+forceCharge = forceCharge.strength(-3000);
+forceCharge = forceCharge.strength(function (node, index, nodes) {
+    let n: SimNode = node;
+    let i: number = index;
+    let ns: Array<SimNode> = nodes;
+    return -1000 * n.group;
+});
+simNodeNumberAccessor = forceCharge.strength();
+
+// theta
+
+forceCharge = forceCharge.theta(0.8);
+num = forceCharge.theta();
+
+
+// distanceMin
+
+forceCharge = forceCharge.distanceMin(1);
+num = forceCharge.distanceMin();
+
+// distanceMax
+
+forceCharge = forceCharge.distanceMax(1000);
+num = forceCharge.distanceMax();
+
+
+// Use ManyBody force -----------------------------------------------------------------
+
+forceCharge.initialize(graph.nodes);
+forceCharge(0.1); // alpha
+
+
+// ForceX ==============================================================================
+
+// create ForceX force --------------------------------------------------------------
+
+let forcePosX: d3Force.ForceX<SimNode>;
+
+forcePosX = d3Force.forceX<SimNode>();
+
+// Configure ForceX force -----------------------------------------------------------
+
+// strength
+
+forcePosX = forcePosX.strength(0.2);
+forcePosX = forcePosX.strength(function (node, index, nodes) {
+    let n: SimNode = node;
+    let i: number = index;
+    let ns: Array<SimNode> = nodes;
+    return 0.1 * n.group;
+});
+simNodeNumberAccessor = forcePosX.strength();
+
+// x
+
+forcePosX = forcePosX.x(100);
+forcePosX = forcePosX.x(function (node, index, nodes) {
+    let n: SimNode = node;
+    let i: number = index;
+    let ns: Array<SimNode> = nodes;
+    let target: number;
+    switch (n.group) {
+        case 1:
+            target = 100;
+            break;
+        case 2:
+            target = 200;
+            break;
+        case 3:
+            target = 300;
+            break;
+        default:
+            target = 0;
+            break;
+    }
+
+    return target;
+});
+
+simNodeNumberAccessor = forcePosX.x();
+
+// Use ForceX force -----------------------------------------------------------------
+
+forcePosX.initialize(graph.nodes);
+forcePosX(0.1); // alpha
+
+
+// ForceY ==============================================================================
+
+// create ForceY force --------------------------------------------------------------
+
+let forcePosY: d3Force.ForceY<SimNode>;
+
+forcePosY = d3Force.forceY<SimNode>();
+
+// Configure ForceY force -----------------------------------------------------------
+
+// strength
+
+forcePosY = forcePosY.strength(0.2);
+forcePosY = forcePosY.strength(function (node, index, nodes) {
+    let n: SimNode = node;
+    let i: number = index;
+    let ns: Array<SimNode> = nodes;
+    return 0.1 * n.group;
+});
+simNodeNumberAccessor = forcePosY.strength();
+
+// y
+
+forcePosY = forcePosY.y(100);
+forcePosY = forcePosY.y(function (node, index, nodes) {
+    let n: SimNode = node;
+    let i: number = index;
+    let ns: Array<SimNode> = nodes;
+    let target: number;
+    switch (n.group) {
+        case 1:
+            target = 100;
+            break;
+        case 2:
+            target = 200;
+            break;
+        case 3:
+            target = 300;
+            break;
+        default:
+            target = 0;
+            break;
+    }
+
+    return target;
+});
+
+simNodeNumberAccessor = forcePosY.y();
+
+// Use ForceY force -----------------------------------------------------------------
+
+forcePosY.initialize(graph.nodes);
+forcePosY(0.1); // alpha
+
+// -------------------------------------------------------------------------------------
+// Test Force Simulation
+// -------------------------------------------------------------------------------------
+
+// Create Force Simulation =============================================================
+
+
+let nodeSimulation: d3Force.Simulation<SimNode, undefined>;
+let nodeLinkSimulation: d3Force.Simulation<SimNode, SimLink>;
+
+// Force Simulation without Links / No node data
+nodeSimulation = d3Force.forceSimulation<SimNode>();
+
+// Force Simulation without Links / With node data
+nodeSimulation = d3Force.forceSimulation<SimNode>(graph.nodes);
+
+// Force Simulation with Links / No node data
+nodeLinkSimulation = d3Force.forceSimulation<SimNode, SimLink>();
+
+// Force Simulation with Links / With node data
+nodeLinkSimulation = d3Force.forceSimulation<SimNode, SimLink>(graph.nodes);
+
+// nodes() -----------------------------------------------------------------------------
+
+nodeSimulation = nodeSimulation.nodes(graph.nodes);
+
+simNodes = nodeSimulation.nodes();
+
+// alpha() -----------------------------------------------------------------------------
+
+nodeLinkSimulation = nodeLinkSimulation.alpha(0.3);
+num = nodeLinkSimulation.alpha();
+
+// alphaMin() -----------------------------------------------------------------------------
+
+nodeLinkSimulation = nodeLinkSimulation.alphaMin(0.0001);
+num = nodeLinkSimulation.alphaMin();
+
+// alphaDecay() -----------------------------------------------------------------------------
+
+nodeLinkSimulation = nodeLinkSimulation.alphaDecay(0.02);
+num = nodeLinkSimulation.alphaDecay();
+
+// alphaTarget() -----------------------------------------------------------------------------
+
+nodeLinkSimulation = nodeLinkSimulation.alphaTarget(0);
+num = nodeLinkSimulation.alphaTarget();
+
+// velocityDecay() -----------------------------------------------------------------------------
+
+nodeLinkSimulation = nodeLinkSimulation.velocityDecay(0.4);
+num = nodeLinkSimulation.velocityDecay();
+
+
+// force() -----------------------------------------------------------------------------
+
+nodeSimulation = nodeSimulation.force('posx', forcePosX);
+nodeSimulation.force('posy', forcePosY);
+
+// Remove force
+nodeSimulation = nodeSimulation.force('posx', null);
+
+
+nodeLinkSimulation = nodeLinkSimulation.force('link', forceLink);
+
+nodeLinkSimulation
+    .force('charge', forceCharge)
+    .force('center', forceCenter);
+
+let f: d3Force.Force<SimNode, SimLink>;
+
+f = nodeLinkSimulation.force('charge');
+f = nodeLinkSimulation.force('link');
+
+let fLink: d3Force.ForceLink<SimNode, SimLink>;
+
+// fLink = nodeLinkSimulation.force('link'); // fails, as ForceLink specific properties are missing from 'generic' force
+
+// Need explicit, careful type casting to a specific force type
+fLink = <d3Force.ForceLink<SimNode, SimLink>>nodeLinkSimulation.force('link');
+
+// This is mainly an issue for ForceLinks, if once wants to get the links from an initialized force
+// or re-set new links for an initialized force, e.g.:
+
+simLinks = (<d3Force.ForceLink<SimNode, SimLink>>nodeLinkSimulation.force('link')).links();
+
+// The same could be followed for custom  forces.
+
+// on() --------------------------------------------------------------------------------
+
+function drawLink(d: SimLink) {
+    let source: SimNode, target: SimNode;
+    source = (typeof d.source !== 'string' && typeof d.source !== 'number') ? d.source : undefined;
+    target = (typeof d.target !== 'string' && typeof d.target !== 'number') ? d.target : undefined;
+    if (source && target) {
+        context.moveTo(source.x, source.y);
+        context.lineTo(target.x, target.y);
+    }
+}
+
+function drawNode(d: SimNode) {
+    context.moveTo(d.x + 3, d.y);
+    context.arc(d.x, d.y, 3, 0, 2 * Math.PI);
+}
+
+nodeLinkSimulation = nodeLinkSimulation.on('tick', function ticked() {
+
+    let that: d3Force.Simulation<SimNode, SimLink> = this;
+
+    context.clearRect(0, 0, width, height);
+
+    context.beginPath();
+    graph.links.forEach(drawLink);
+    context.strokeStyle = '#aaa';
+    context.stroke();
+
+    context.beginPath();
+    graph.nodes.forEach(drawNode);
+    context.fill();
+    context.strokeStyle = '#fff';
+    context.stroke();
+});
+
+// remove listener
+nodeSimulation = nodeSimulation.on('tick', null);
+
+// Configure and Use Force Simulation ===================================================
+
+// restart() --------------------------------------------------------------------------
+
+nodeLinkSimulation.restart();
+
+// stop() -----------------------------------------------------------------------------
+
+nodeLinkSimulation.stop();
+
+// tick() -----------------------------------------------------------------------------
+
+nodeLinkSimulation.tick();
+
+// find() -----------------------------------------------------------------------------
+
+simNode = nodeLinkSimulation.find(100, 100);
+simNode = nodeLinkSimulation.find(100, 100, 20);


### PR DESCRIPTION
- Added signature to remove a force from Simulation by passing in null
- cleaned-up signatures for pre-defined sources
- Changed interface names from ForcePositionX and ForcePostitionY to ForceX and ForceY, respectively. This is aligned with naming convention followed for the other forces (i.e. simple capitalization of generator name)
- Completed tests  for d3-force.
- Fixes #29. Fixes #57.
  Updated README to check off d3-force
