### PR TITLE
Optional module: d3-selection-multi

### DIFF
--- a/src/d3-selection-multi/index.d.ts
+++ b/src/d3-selection-multi/index.d.ts
@@ -3,7 +3,93 @@
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import {Selection} from '../d3-selection';
+import {Selection, BaseType, ArrayLike} from '../d3-selection';
 import {Transition} from '../d3-transition';
 
-// TODO: Write Definitions
+// Callback type for selections and transitions
+type ValueFn<Element, Datum, Result> = (this: Element, datum: Datum, index: number, groups: Array<Element> | ArrayLike<Element>) => Result;
+
+// An object mapping attribute (or style or property) names to value accessors
+type ValueMap<Element, Datum> = { [key: string]: number | string | boolean | null | ValueFn<Element, Datum, number | string | boolean | null> };
+
+declare module '../d3-selection' {
+    export interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
+        /**
+         * Set multiple attributes on the given selection. Attribute values may be constant or derived from each node and its bound data.
+         *
+         * @param attrs An object used as a map of attribute names to set
+         */
+        attrs(attrs: ValueMap<GElement, Datum>): this;
+
+        /**
+         * Derive a map of attributes to be set on the selection.
+         *
+         * @param attrs A function that returns an object of attribute names and values to set.
+         */
+        attrs(attrs: ValueFn<GElement, Datum, ValueMap<GElement, Datum>>): this;
+
+        /**
+         * Set multiple CSS style properties on the given selection. Style properties may be constant or derived from each node and its bound data.
+         *
+         * @param style An object used as a map of style properties to set.
+         * @param priority The CSS priority (either "important" or undefined).
+         */
+        styles(style: ValueMap<GElement, Datum>, priority?: 'important'): this;
+
+        /**
+         * Derive a map of style properties to be set on the selection.
+         *
+         * @param style A function that returns an object of style properties and the values to be set.
+         * @param priority The CSS priority (either "important" or undefined)
+         */
+        styles(style: ValueFn<GElement, Datum, ValueMap<GElement, Datum>>, priority?: 'important'): this;
+
+        /**
+         * Set multiple object properties directly on the selection's node(s). Property values may be constants or derived from each node and its bound data.
+         *
+         * @param props An object used as a map of object properties to be set.
+         */
+        properties(props: ValueMap<GElement, Datum>): this;
+
+        /**
+         * Derive a map of object properties to be set on the selection's node(s).
+         *
+         * @param props A function that returns an object of properties and their values.
+         */
+        properties(props: ValueFn<GElement, Datum, ValueMap<GElement, Datum>>): this;
+    }
+}
+
+declare module '../d3-transition' {
+    export interface Transition<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
+        /**
+         * Set multiple attribute values. The transition will animate from the present value to the new value. Attribute values may be constant or derived from each node and its bound data.
+         *
+         * @param attrs An object used as a map of attributes and their values.
+         */
+        attrs(attrs: ValueMap<GElement, Datum>): this;
+
+        /**
+         * Derive a map of attribute values to set.
+         *
+         * @param attrs A function returning a map of attributes and their values.
+         */
+        attrs(attrs: ValueFn<GElement, Datum, ValueMap<GElement, Datum>>): this;
+
+        /**
+         * Set multiple style properties. The transition will animate from the present value to the new value. Attribute values may be constant or derived from each node and its bound data.
+         *
+         * @param style A map of style properties and their values
+         * @param priority The CSS priority (either "important" or undefined)
+         */
+        styles(style: ValueMap<GElement, Datum>, priority?: 'important'): this;
+
+        /**
+         * Derive a map of style properties to be set.
+         *
+         * @param style A function returning a map of style properties and their values
+         * @param priority The CSS priority (either "important" or undefined)
+         */
+        styles(style: ValueFn<GElement, Datum, ValueMap<GElement, Datum>>, priority?: 'important'): this;
+    }
+}

--- a/tests/d3-selection-multi/d3-selection-multi-test.ts
+++ b/tests/d3-selection-multi/d3-selection-multi-test.ts
@@ -12,4 +12,140 @@ import {Transition} from '../../src/d3-transition';
 
 import '../../src/d3-selection-multi';
 
-// Add tests of augmentation
+let selection: Selection<HTMLAnchorElement, string, null, undefined>;
+
+// Selection.attrs
+
+// Simple object
+selection = selection.attrs({
+    foo: 1,
+    bar: '2',
+    baz: true,
+});
+
+// Function values
+selection = selection.attrs({
+    foo: () => 1,
+    bar: (d) => d,
+    baz: (d, i) => i !== 0,
+    bat: function () {
+        return this.href;
+    },
+});
+
+// Function that returns a map
+selection = selection.attrs(function (d) {
+    return this.id ? null : { id: d };
+});
+
+// Selection.styles
+// Each test is repeated twice: once without the priority, and another time with
+
+// Simple object
+selection = selection.styles({
+    top: 0,
+    color: 'red',
+});
+
+selection = selection.styles({
+    top: 0,
+    color: 'red',
+}, 'important');
+
+// Function values
+selection = selection.styles({
+    top: (d, i) => i + 'px',
+    color: d => d,
+});
+
+selection = selection.styles({
+    top: (d, i) => i + 'px',
+    color: d => d,
+}, 'important');
+
+// Functions that return a map
+selection.styles(function (d) {
+    return this.id ? { color: 'red' } : { color: d };
+});
+
+selection = selection.styles(function (d) {
+    return this.id ? { color: 'red' } : { color: d };
+}, 'important');
+
+// Selection.properties
+// Simple object
+selection = selection.properties({
+    foo: 1,
+    bar: 'bar',
+});
+
+// Function values
+selection = selection.properties({
+    foo: (d, i) => i,
+    bar: d => d,
+});
+
+// Function that returns an object
+selection = selection.properties(function (d) {
+    return this.href ? null : { href: d };
+});
+
+let transition: Transition<HTMLAnchorElement, string, null, undefined>;
+
+// Transition.attrs
+
+// Simple object
+transition = transition.attrs({
+    foo: 1,
+    bar: '2',
+    baz: true,
+});
+
+// Function values
+transition = transition.attrs({
+    foo: () => 1,
+    bar: (d) => d,
+    baz: (d, i) => i !== 0,
+    bat: function () {
+        return this.href;
+    },
+});
+
+// Function that returns a map
+transition = transition.attrs(function (d) {
+    return this.id ? null : { id: d };
+});
+
+// Transition.styles
+// As above, the tests are repeated with the priority 'important' passed in
+
+// Simple object
+transition = transition.styles({
+    top: 0,
+    color: 'red',
+});
+
+transition = transition.styles({
+    top: 0,
+    color: 'red',
+}, 'important');
+
+// Function values
+transition = transition.styles({
+    top: (d, i) => i + 'px',
+    color: d => d,
+});
+
+transition = transition.styles({
+    top: (d, i) => i + 'px',
+    color: d => d,
+}, 'important');
+
+// Function that returns a map
+transition = transition.styles(function (d) {
+    return this.id ? { color: 'red' } : { color: d };
+});
+
+transition = transition.styles(function (d) {
+    return this.id ? { color: 'red' } : { color: d };
+}, 'important');


### PR DESCRIPTION
This PR adds definitions for the `d3-selection-multi` module. This addresses both #33 and #60, mostly because I forgot they were separate issues. My bad.

I did end up having to use two type aliases because the full type definition is nearly 500 characters long and reads more like an eldritch curse than anything else.
