### PR TITLE
Chore: Add more optional module skeletons. d3-timer missing space.

### DIFF
--- a/src/d3-geo-projection/index.d.ts
+++ b/src/d3-geo-projection/index.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for D3JS d3-geo-projection module 1.0.3
+// Project: https://github.com/d3/d3-geo-projection/
+// Definitions by:
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/src/d3-geo-projection/typings.json
+++ b/src/d3-geo-projection/typings.json
@@ -1,0 +1,12 @@
+{
+  "name": "d3-geo-projection",
+  "homepage": "https://github.com/d3/d3-geo-projection",
+  "version": "1.0.3",
+  "global": false,
+  "main": "index.d.ts",
+  "files": [
+    "index.d.ts"
+  ],
+  "dependencies": {},
+  "globalDependencies": {}
+}

--- a/src/d3-hexbin/index.d.ts
+++ b/src/d3-hexbin/index.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for D3JS d3-hexbin module 0.2.0
+// Project: https://github.com/d3/d3-hexbin/
+// Definitions by:
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/src/d3-hexbin/typings.json
+++ b/src/d3-hexbin/typings.json
@@ -1,0 +1,12 @@
+{
+  "name": "d3-hexbin",
+  "homepage": "https://github.com/d3/d3-hexbin",
+  "version": "0.2.0",
+  "global": false,
+  "main": "index.d.ts",
+  "files": [
+    "index.d.ts"
+  ],
+  "dependencies": {},
+  "globalDependencies": {}
+}

--- a/src/d3-hsv/index.d.ts
+++ b/src/d3-hsv/index.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for D3JS d3-hsv module 0.0.3
+// Project: https://github.com/d3/d3-hsv/
+// Definitions by:
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/src/d3-hsv/typings.json
+++ b/src/d3-hsv/typings.json
@@ -1,0 +1,12 @@
+{
+  "name": "d3-geo-hsv",
+  "homepage": "https://github.com/d3/d3-hsv",
+  "version": "0.0.3",
+  "global": false,
+  "main": "index.d.ts",
+  "files": [
+    "index.d.ts"
+  ],
+  "dependencies": {},
+  "globalDependencies": {}
+}

--- a/src/d3-sankey/index.d.ts
+++ b/src/d3-sankey/index.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for D3JS d3-sankey module 0.2.0
+// Project: https://github.com/d3/d3-sankey/
+// Definitions by:
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/src/d3-sankey/typings.json
+++ b/src/d3-sankey/typings.json
@@ -1,0 +1,12 @@
+{
+  "name": "d3-sankey",
+  "homepage": "https://github.com/d3/d3-sankey",
+  "version": "0.2.0",
+  "global": false,
+  "main": "index.d.ts",
+  "files": [
+    "index.d.ts"
+  ],
+  "dependencies": {},
+  "globalDependencies": {}
+}

--- a/src/d3-tile/index.d.ts
+++ b/src/d3-tile/index.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for D3JS d3-tile module 0.0.3
+// Project: https://github.com/d3/d3-tile/
+// Definitions by:
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped

--- a/src/d3-tile/typings.json
+++ b/src/d3-tile/typings.json
@@ -1,0 +1,12 @@
+{
+  "name": "d3-tile",
+  "homepage": "https://github.com/d3/d3-tile",
+  "version": "0.0.3",
+  "global": false,
+  "main": "index.d.ts",
+  "files": [
+    "index.d.ts"
+  ],
+  "dependencies": {},
+  "globalDependencies": {}
+}

--- a/src/d3-timer/index.d.ts
+++ b/src/d3-timer/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for d3JS d3-timer module 1.0.1
 // Project: https://github.com/d3/d3-timer/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek<https://github.com/tomwanzek>
+// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/tests/d3-geo-projection/d3-geo-projection-test.ts
+++ b/tests/d3-geo-projection/d3-geo-projection-test.ts
@@ -1,0 +1,10 @@
+/**
+ * Typescript definition tests for d3/d3-geo-projection module
+ *
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
+
+// TODO: uncomment below and add tests
+// import * as d3GeoProj from '../../src/d3-geo-projection';

--- a/tests/d3-hexbin/d3-hexbin-test.ts
+++ b/tests/d3-hexbin/d3-hexbin-test.ts
@@ -1,0 +1,10 @@
+/**
+ * Typescript definition tests for d3/d3-hexbin module
+ *
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
+
+// TODO: uncomment below and add tests
+// import * as d3Hexbin from '../../src/d3-hexbin';

--- a/tests/d3-hsv/d3-hsv-test.ts
+++ b/tests/d3-hsv/d3-hsv-test.ts
@@ -1,0 +1,10 @@
+/**
+ * Typescript definition tests for d3/d3-hsv module
+ *
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
+
+// TODO: uncomment below and add tests
+// import * as d3Hsv from '../../src/d3-hsv';

--- a/tests/d3-sankey/d3-sankey-test.ts
+++ b/tests/d3-sankey/d3-sankey-test.ts
@@ -1,0 +1,10 @@
+/**
+ * Typescript definition tests for d3/d3-sankey module
+ *
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
+
+// TODO: uncomment below and add tests
+// import * as d3Sankey from '../../src/d3-sankey';

--- a/tests/d3-tile/d3-tile-test.ts
+++ b/tests/d3-tile/d3-tile-test.ts
@@ -1,0 +1,10 @@
+/**
+ * Typescript definition tests for d3/d3-tile module
+ *
+ * Note: These tests are intended to test the definitions only
+ * in the sense of typing and call signature consistency. They
+ * are not intended as functional tests.
+ */
+
+// TODO: uncomment below and add tests
+// import * as d3Tile from '../../src/d3-tile';


### PR DESCRIPTION
- Added definition and test file skeletons for the optional D3 modules: d3-geo-projection, d3-hexbin, d3-hsv, d3-sankey  and d3-tile. Fixes #82.
- d3-timer: Fixed missing space in DefinitionsBy header.
