### PR TITLE
Completion of follow-up Chores, Bug Fixes and Generalizations

### DIFF
--- a/src/d3-axis/index.d.ts
+++ b/src/d3-axis/index.d.ts
@@ -73,7 +73,7 @@ export interface Axis<Domain> {
      *
      * @param scale  The scale to be used for axis generation
      */
-    scale(scale: AxisScale<Domain>): Axis<Domain>;
+    scale(scale: AxisScale<Domain>): this;
 
     /**
      * Sets the arguments that will be passed to scale.ticks and scale.tickFormat when the axis is rendered, and returns the axis generator.
@@ -81,7 +81,7 @@ export interface Axis<Domain> {
      * @param count Number of ticks that should be rendered
      * @param specifier An optional format specifier to customize how the tick values are formatted.
      */
-    ticks(count: number, specifier?: string): Axis<Domain>;
+    ticks(count: number, specifier?: string): this;
 
     /**
      * Sets the arguments that will be passed to scale.ticks and scale.tickFormat when the axis is rendered, and returns the axis generator.
@@ -91,12 +91,12 @@ export interface Axis<Domain> {
      * in d3-time. E.g. as obtained by passing in d3.timeMinute.every(15).
      * @param specifier An optional format specifier to customize how the tick values are formatted.
      */
-    ticks(interval: AxisTimeInterval, specifier?: string): Axis<Domain>;
+    ticks(interval: AxisTimeInterval, specifier?: string): this;
 
     /**
      * Sets the arguments that will be passed to scale.ticks and scale.tickFormat when the axis is rendered, and returns the axis generator.
      */
-    ticks(arg0: any, ...args: any[]): Axis<Domain>;
+    ticks(arg0: any, ...args: any[]): this;
 
     /**
      * Get an array containing the currently set arguments to be passed into scale.ticks and scale.tickFormat.
@@ -108,7 +108,7 @@ export interface Axis<Domain> {
      *
      * @param args An array containing a single element representing the count, i.e. number of ticks to be rendered.
      */
-    tickArguments(args: [number]): Axis<Domain>;
+    tickArguments(args: [number]): this;
 
     /**
      * Sets the arguments that will be passed to scale.ticks and scale.tickFormat when the axis is rendered, and returns the axis generator.
@@ -116,7 +116,7 @@ export interface Axis<Domain> {
      * @param args An array containing two elements. The first element represents the count, i.e. number of ticks to be rendered. The second
      * element is a string representing the format specifier to customize how the tick values are formatted.
      */
-    tickArguments(args: [number, string]): Axis<Domain>;
+    tickArguments(args: [number, string]): this;
 
     /**
      * Sets the arguments that will be passed to scale.ticks and scale.tickFormat when the axis is rendered, and returns the axis generator.
@@ -125,7 +125,7 @@ export interface Axis<Domain> {
      * @param args An array containing a single element representing a time interval used to generate date-based ticks.
      * This is typically a TimeInterval/CountableTimeInterval as defined in d3-time. E.g. as obtained by passing in d3.timeMinute.every(15).
      */
-    tickArguments(args: [AxisTimeInterval]): Axis<Domain>;
+    tickArguments(args: [AxisTimeInterval]): this;
 
     /**
      * Sets the arguments that will be passed to scale.ticks and scale.tickFormat when the axis is rendered, and returns the axis generator.
@@ -135,14 +135,14 @@ export interface Axis<Domain> {
      * This is typically a TimeInterval/CountableTimeInterval as defined in d3-time. E.g. as obtained by passing in d3.timeMinute.every(15).
      * The second element is a string representing the format specifier to customize how the tick values are formatted.
      */
-    tickArguments(args: [AxisTimeInterval, string]): Axis<Domain>;
+    tickArguments(args: [AxisTimeInterval, string]): this;
 
     /**
     * Sets the arguments that will be passed to scale.ticks and scale.tickFormat when the axis is rendered, and returns the axis generator.
     *
     * @param args An array with arguments suitable for the scale to be used for tick generation
     */
-    tickArguments(args: any[]): Axis<Domain>;
+    tickArguments(args: any[]): this;
 
     /**
      * Returns the current tick values, which defaults to null.
@@ -157,14 +157,14 @@ export interface Axis<Domain> {
      *
      * @param values An array with values from the Domain of the scale underlying the axis.
      */
-    tickValues(values: Domain[]): Axis<Domain>;
+    tickValues(values: Domain[]): this;
 
     /**
      * Clears any previously-set explicit tick values and reverts back to the scale’s tick generator.
      *
      * @param values null
      */
-    tickValues(values: null): Axis<Domain>;
+    tickValues(values: null): this;
 
 
     /**
@@ -178,7 +178,7 @@ export interface Axis<Domain> {
      * @param format A function mapping a value from the axis Domain to a formatted string
      * for display purposes.
      */
-    tickFormat(format: (domainValue: Domain) => string): Axis<Domain>;
+    tickFormat(format: (domainValue: Domain) => string): this;
 
     /**
      * Reset the tick format function. A null format indicates that the scale’s
@@ -188,7 +188,7 @@ export interface Axis<Domain> {
      *
      * @param format null
      */
-    tickFormat(format: null): Axis<Domain>;
+    tickFormat(format: null): this;
 
     /**
      * Get the current inner tick size, which defaults to 6.
@@ -199,7 +199,7 @@ export interface Axis<Domain> {
      *
      * @param size Tick size in pixels (Default is 6).
      */
-    tickSize(size: number): Axis<Domain>;
+    tickSize(size: number): this;
 
     /**
      * Get the current inner tick size, which defaults to 6.
@@ -215,7 +215,7 @@ export interface Axis<Domain> {
      *
      * @param size Tick size in pixels (Default is 6).
      */
-    tickSizeInner(size: number): Axis<Domain>;
+    tickSizeInner(size: number): this;
 
     /**
      * Get the current outer tick size, which defaults to 6.
@@ -239,7 +239,7 @@ export interface Axis<Domain> {
      *
      * @param size Tick size in pixels (Default is 6).
      */
-    tickSizeOuter(size: number): Axis<Domain>;
+    tickSizeOuter(size: number): this;
 
     /**
      * Get the current padding, which defaults to 3.
@@ -251,7 +251,7 @@ export interface Axis<Domain> {
      *
      * @param padding Padding in pixels  (Default is 3).
      */
-    tickPadding(padding: number): Axis<Domain>;
+    tickPadding(padding: number): this;
 
 }
 

--- a/src/d3-brush/index.d.ts
+++ b/src/d3-brush/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ArrayLike, Selection, TransitionLike } from '../d3-selection';
+import { ArrayLike, Selection, TransitionLike, ValueFn } from '../d3-selection';
 
 /**
  * Type alias for a BrushSelection. For a two-dimensional brush, it must be defined as [[x0, y0], [x1, y1]],
@@ -15,20 +15,20 @@ export type BrushSelection = [[number, number], [number, number]] | [number, num
 
 export interface BrushBehavior<Datum> {
     (group: Selection<SVGGElement, Datum, any, any>, ...args: any[]): void;
-    move(group: Selection<SVGGElement, Datum, any, any>, selection: BrushSelection): BrushBehavior<Datum>;
-    move(group: Selection<SVGGElement, Datum, any, any>, selection: (this: SVGGElement, d?: Datum, i?: number, group?: Array<SVGGElement> | ArrayLike<SVGGElement>) => BrushSelection): BrushBehavior<Datum>;
-    move(group: TransitionLike<SVGGElement, Datum>, selection: BrushSelection): BrushBehavior<Datum>;
-    move(group: TransitionLike<SVGGElement, Datum>, selection: (this: SVGGElement, d?: Datum, i?: number, group?: Array<SVGGElement> | ArrayLike<SVGGElement>) => BrushSelection): BrushBehavior<Datum>;
-    extent(): (this: SVGGElement, d: Datum, i: number, group: Array<SVGGElement> | ArrayLike<SVGGElement>) => [[number, number], [number, number]];
-    extent(extent: [[number, number], [number, number]]): BrushBehavior<Datum>;
-    extent(extent: (this: SVGGElement, d: Datum, i: number, group: Array<SVGGElement> | ArrayLike<SVGGElement>) => [[number, number], [number, number]]): BrushBehavior<Datum>;
-    filter(): (this: SVGGElement, datum: Datum, index: number, group: Array<SVGGElement> | ArrayLike<SVGGElement>) => boolean;
-    filter(filterFn: (this: SVGGElement, datum: Datum, index: number, group: Array<SVGGElement> | ArrayLike<SVGGElement>) => boolean): BrushBehavior<Datum>;
+    move(group: Selection<SVGGElement, Datum, any, any>, selection: BrushSelection): void;
+    move(group: Selection<SVGGElement, Datum, any, any>, selection: ValueFn<SVGGElement, Datum, BrushSelection>): void;
+    move(group: TransitionLike<SVGGElement, Datum>, selection: BrushSelection): void;
+    move(group: TransitionLike<SVGGElement, Datum>, selection: ValueFn<SVGGElement, Datum, BrushSelection>): void;
+    extent(): ValueFn<SVGGElement, Datum, [[number, number], [number, number]]>;
+    extent(extent: [[number, number], [number, number]]): this;
+    extent(extent: ValueFn<SVGGElement, Datum, [[number, number], [number, number]]>): this;
+    filter(): ValueFn<SVGGElement, Datum, boolean>;
+    filter(filterFn: ValueFn<SVGGElement, Datum, boolean>): this;
     handleSize(): number;
-    handleSize(size: number): BrushBehavior<Datum>;
-    on(typenames: string): (this: SVGGElement, datum: Datum, index: number, group: Array<SVGGElement> | ArrayLike<SVGGElement>) => void;
-    on(typenames: string, callback: null): BrushBehavior<Datum>;
-    on(typenames: string, callback: (this: SVGGElement, datum: Datum, index: number, group: Array<SVGGElement> | ArrayLike<SVGGElement>) => void): BrushBehavior<Datum>;
+    handleSize(size: number): this;
+    on(typenames: string): ValueFn<SVGGElement, Datum, void>;
+    on(typenames: string, callback: null): this;
+    on(typenames: string, callback: ValueFn<SVGGElement, Datum, void>): this;
 
 }
 

--- a/src/d3-chord/index.d.ts
+++ b/src/d3-chord/index.d.ts
@@ -34,16 +34,16 @@ export interface Chords extends Array<Chord> {
 export interface ChordLayout {
     (matrix: number[][]): Chords;
     padAngle(): number;
-    padAngle(angle: number): ChordLayout;
+    padAngle(angle: number): this;
     sortGroups(): ((a: number, b: number) => number) | null;
-    sortGroups(compare: null): ChordLayout;
-    sortGroups(compare: (a: number, b: number) => number): ChordLayout;
+    sortGroups(compare: null): this;
+    sortGroups(compare: (a: number, b: number) => number): this;
     sortSubgroups(): ((a: number, b: number) => number) | null;
-    sortSubgroups(compare: null): ChordLayout;
-    sortSubgroups(compare: (a: number, b: number) => number): ChordLayout;
+    sortSubgroups(compare: null): this;
+    sortSubgroups(compare: (a: number, b: number) => number): this;
     sortChords(): ((a: number, b: number) => number) | null;
-    sortChords(compare: null): ChordLayout;
-    sortChords(compare: (a: number, b: number) => number): ChordLayout;
+    sortChords(compare: null): this;
+    sortChords(compare: (a: number, b: number) => number): this;
 }
 
 export function chord(): ChordLayout;
@@ -56,21 +56,21 @@ export function chord(): ChordLayout;
 export interface RibbonGenerator<This, ChordDatum, ChordSubgroupDatum> {
     (this: This, d: ChordDatum, ...args: any[]): string | undefined;
     source(): (this: This, d: ChordDatum, ...args: any[]) => ChordSubgroupDatum;
-    source(source: (this: This, d: ChordDatum, ...args: any[]) => ChordSubgroupDatum): RibbonGenerator<This, ChordDatum, ChordSubgroupDatum>;
+    source(source: (this: This, d: ChordDatum, ...args: any[]) => ChordSubgroupDatum): this;
     target(): (this: This, d: ChordDatum, ...args: any[]) => ChordSubgroupDatum;
-    target(target: (this: This, d: ChordDatum, ...args: any[]) => ChordSubgroupDatum): RibbonGenerator<This, ChordDatum, ChordSubgroupDatum>;
+    target(target: (this: This, d: ChordDatum, ...args: any[]) => ChordSubgroupDatum): this;
     radius(): (this: This, d: ChordSubgroupDatum, ...args: any[]) => number;
-    radius(radius: number): RibbonGenerator<This, ChordDatum, ChordSubgroupDatum>;
-    radius(radius: (this: This, d: ChordSubgroupDatum, ...args: any[]) => number): RibbonGenerator<This, ChordDatum, ChordSubgroupDatum>;
+    radius(radius: number): this;
+    radius(radius: (this: This, d: ChordSubgroupDatum, ...args: any[]) => number): this;
     startAngle(): (this: This, d: ChordSubgroupDatum, ...args: any[]) => number;
-    startAngle(angle: number): RibbonGenerator<This, ChordDatum, ChordSubgroupDatum>;
-    startAngle(angle: (this: This, d: ChordSubgroupDatum, ...args: any[]) => number): RibbonGenerator<This, ChordDatum, ChordSubgroupDatum>;
+    startAngle(angle: number): this;
+    startAngle(angle: (this: This, d: ChordSubgroupDatum, ...args: any[]) => number): this;
     endAngle(): (this: This, d: ChordSubgroupDatum, ...args: any[]) => number;
-    endAngle(angle: number): RibbonGenerator<This, ChordDatum, ChordSubgroupDatum>;
-    endAngle(angle: (this: This, d: ChordSubgroupDatum, ...args: any[]) => number): RibbonGenerator<This, ChordDatum, ChordSubgroupDatum>;
+    endAngle(angle: number): this;
+    endAngle(angle: (this: This, d: ChordSubgroupDatum, ...args: any[]) => number): this;
     context(): CanvasRenderingContext2D | null;
-    context(context: CanvasRenderingContext2D): RibbonGenerator<This, ChordDatum, ChordSubgroupDatum>;
-    context(context: null): RibbonGenerator<This, ChordDatum, ChordSubgroupDatum>;
+    context(context: CanvasRenderingContext2D): this;
+    context(context: null): this;
 }
 
 export function ribbon(): RibbonGenerator<any, Chord, ChordSubgroup>;

--- a/src/d3-collection/index.d.ts
+++ b/src/d3-collection/index.d.ts
@@ -104,10 +104,10 @@ export interface NestedObject<Datum, RollupType> {
 }
 
 interface Nest<Datum, RollupType> {
-    key(func: (datum: Datum) => string): Nest<Datum, RollupType>;
-    sortKeys(comparator: (a: string, b: string) => number): Nest<Datum, RollupType>;
-    sortValues(comparator: (a: Datum, b: Datum) => number): Nest<Datum, RollupType>;
-    rollup(func: (values: Datum[]) => RollupType): Nest<Datum, RollupType>;
+    key(func: (datum: Datum) => string): this;
+    sortKeys(comparator: (a: string, b: string) => number): this;
+    sortValues(comparator: (a: Datum, b: Datum) => number): this;
+    rollup(func: (values: Datum[]) => RollupType): this;
     map(array: Datum[]): Map<any>; // more specifically it returns NestedMap<Datum, RollupType>
     object(array: Datum[]): { [key: string]: any };  // more specifically it returns NestedObject<Datum, RollupType>
     entries(array: Datum[]): Array<{ key: string; values: any; value: RollupType | undefined }>;  // more specifically it returns NestedArray<Datum, RollupType>

--- a/src/d3-color/index.d.ts
+++ b/src/d3-color/index.d.ts
@@ -12,6 +12,17 @@
  */
 export type ColorSpaceObject = RGBColor | HSLColor | LabColor | HCLColor | CubehelixColor;
 
+/**
+ * A helper interface of methods common to color objects (including colors defined outside the d3-color standard module,
+ * e.g. in d3-hsv). This interface
+ */
+export interface ColorCommonInstance {
+    displayable(): boolean;
+    toString(): string;
+    brighter(k?: number): this;
+    darker(k?: number): this;
+    rgb(): RGBColor;
+}
 
 export interface Color {
     displayable(): boolean; // Note: While this method is used in prototyping for colors of specific colorspaces, it should not be called directly, as 'this.rgb' would not be implemented on Color
@@ -20,7 +31,7 @@ export interface Color {
 
 export interface ColorFactory extends Function {
     (cssColorSpecifier: string): RGBColor | HSLColor;
-    (color: ColorSpaceObject): RGBColor | HSLColor;
+    (color: ColorSpaceObject | ColorCommonInstance): RGBColor | HSLColor;
     //    prototype: Color;
 }
 
@@ -29,8 +40,8 @@ export interface RGBColor extends Color {
     g: number;
     b: number;
     opacity: number;
-    brighter(k?: number): RGBColor;
-    darker(k?: number): RGBColor;
+    brighter(k?: number): this;
+    darker(k?: number): this;
     displayable(): boolean;
     rgb(): RGBColor;
     toString(): string;
@@ -39,7 +50,7 @@ export interface RGBColor extends Color {
 export interface RGBColorFactory extends Function {
     (r: number, g: number, b: number, opacity?: number): RGBColor;
     (cssColorSpecifier: string): RGBColor;
-    (color: ColorSpaceObject): RGBColor;
+    (color: ColorSpaceObject | ColorCommonInstance): RGBColor;
     //    prototype: RGBColor;
 }
 
@@ -48,8 +59,8 @@ export interface HSLColor extends Color {
     s: number;
     l: number;
     opacity: number;
-    brighter(k?: number): HSLColor;
-    darker(k?: number): HSLColor;
+    brighter(k?: number): this;
+    darker(k?: number): this;
     displayable(): boolean;
     rgb(): RGBColor;
 }
@@ -57,7 +68,7 @@ export interface HSLColor extends Color {
 export interface HSLColorFactory extends Function {
     (h: number, s: number, l: number, opacity?: number): HSLColor;
     (cssColorSpecifier: string): HSLColor;
-    (color: ColorSpaceObject): HSLColor;
+    (color: ColorSpaceObject | ColorCommonInstance): HSLColor;
     //    prototype: HSLColor;
 }
 
@@ -66,15 +77,15 @@ export interface LabColor extends Color {
     a: number;
     b: number;
     opacity: number;
-    brighter(k?: number): LabColor;
-    darker(k?: number): LabColor;
+    brighter(k?: number): this;
+    darker(k?: number): this;
     rgb(): RGBColor;
 }
 
 export interface LabColorFactory extends Function {
     (l: number, a: number, b: number, opacity?: number): LabColor;
     (cssColorSpecifier: string): LabColor;
-    (color: ColorSpaceObject): LabColor;
+    (color: ColorSpaceObject | ColorCommonInstance): LabColor;
     //    prototype: LabColor;
 }
 
@@ -83,15 +94,15 @@ export interface HCLColor extends Color {
     c: number;
     l: number;
     opacity: number;
-    brighter(k?: number): HCLColor;
-    darker(k?: number): HCLColor;
+    brighter(k?: number): this;
+    darker(k?: number): this;
     rgb(): RGBColor;
 }
 
 export interface HCLColorFactory extends Function {
     (h: number, l: number, c: number, opacity?: number): HCLColor;
     (cssColorSpecifier: string): HCLColor;
-    (color: ColorSpaceObject): HCLColor;
+    (color: ColorSpaceObject | ColorCommonInstance): HCLColor;
     //    prototype: HCLColor;
 }
 
@@ -100,15 +111,15 @@ export interface CubehelixColor extends Color {
     s: number;
     l: number;
     opacity: number;
-    brighter(k?: number): CubehelixColor;
-    darker(k?: number): CubehelixColor;
+    brighter(k?: number): this;
+    darker(k?: number): this;
     rgb(): RGBColor;
 }
 
 export interface CubehelixColorFactory extends Function {
     (h: number, s: number, l: number, opacity?: number): CubehelixColor;
     (cssColorSpecifier: string): CubehelixColor;
-    (color: ColorSpaceObject): CubehelixColor;
+    (color: ColorSpaceObject | ColorCommonInstance): CubehelixColor;
     //    prototype: CubehelixColor;
 }
 

--- a/src/d3-dispatch/index.d.ts
+++ b/src/d3-dispatch/index.d.ts
@@ -9,8 +9,8 @@ export interface Dispatch<T extends EventTarget> {
     copy(): Dispatch<T>;
 
     on(typenames: string): (this: T, ...args: any[]) => void;
-    on(typenames: string, callback: null): Dispatch<T>;
-    on(typenames: string, callback: (this: T, ...args: any[]) => void): Dispatch<T>;
+    on(typenames: string, callback: null): this;
+    on(typenames: string, callback: (this: T, ...args: any[]) => void): this;
 }
 
 export function dispatch<T extends EventTarget>(...types: string[]): Dispatch<T>;

--- a/src/d3-drag/index.d.ts
+++ b/src/d3-drag/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ArrayLike, Selection } from '../d3-selection';
+import { ArrayLike, Selection, ValueFn } from '../d3-selection';
 
 
 // --------------------------------------------------------------------------
@@ -35,16 +35,16 @@ export interface SubjectPosition {
 
 export interface DragBehavior<GElement extends DraggedElementBaseType, Datum, Subject> extends Function {
     (selection: Selection<GElement, Datum, any, any>, ...args: any[]): void;
-    container(): (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => DragContainerElement;
-    container(accessor: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => DragContainerElement): DragBehavior<GElement, Datum, Subject>;
-    container(container: DragContainerElement): DragBehavior<GElement, Datum, Subject>;
-    filter(): (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => boolean;
-    filter(filterFn: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => boolean): DragBehavior<GElement, Datum, Subject>;
-    subject(): (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => Subject;
-    subject(accessor: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => Subject): DragBehavior<GElement, Datum, Subject>;
-    on(typenames: string): (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => any;
-    on(typenames: string, callback: null): DragBehavior<GElement, Datum, Subject>;
-    on(typenames: string, callback: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => any): DragBehavior<GElement, Datum, Subject>;
+    container(): ValueFn<GElement, Datum, DragContainerElement>;
+    container(accessor: ValueFn<GElement, Datum, DragContainerElement>): this;
+    container(container: DragContainerElement): this;
+    filter(): ValueFn<GElement, Datum, boolean>;
+    filter(filterFn: ValueFn<GElement, Datum, boolean>): this;
+    subject(): ValueFn<GElement, Datum, Subject>;
+    subject(accessor: ValueFn<GElement, Datum, Subject>): this;
+    on(typenames: string): ValueFn<GElement, Datum, void>;
+    on(typenames: string, callback: null): this;
+    on(typenames: string, callback: ValueFn<GElement, Datum, void>): this;
 }
 
 export function drag<GElement extends DraggedElementBaseType, Datum>(): DragBehavior<GElement, Datum, Datum | SubjectPosition>;
@@ -62,9 +62,9 @@ export interface D3DragEvent<GElement extends DraggedElementBaseType, Datum, Sub
     identifier: 'mouse' | number;
     active: number;
     sourceEvent: any;
-    on(typenames: string): (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => void;
-    on(typenames: string, callback: null): D3DragEvent<GElement, Datum, Subject>;
-    on(typenames: string, callback: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => void): D3DragEvent<GElement, Datum, Subject>;
+    on(typenames: string): ValueFn<GElement, Datum, void>;
+    on(typenames: string, callback: null): this;
+    on(typenames: string, callback: ValueFn<GElement, Datum, void>): this;
 }
 
 export function dragDisable(window: Window): void;

--- a/src/d3-force/index.d.ts
+++ b/src/d3-force/index.d.ts
@@ -31,28 +31,28 @@ export interface SimulationLinkDatum<NodeDatum extends SimulationNodeDatum> {
 }
 
 export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> {
-    restart(): Simulation<NodeDatum, LinkDatum>;
-    stop(): Simulation<NodeDatum, LinkDatum>;
-    tick(): Simulation<NodeDatum, LinkDatum>;
+    restart(): this;
+    stop(): this;
+    tick(): void;
     nodes(): Array<NodeDatum>;
-    nodes(nodesData: Array<NodeDatum>): Simulation<NodeDatum, LinkDatum>;
+    nodes(nodesData: Array<NodeDatum>): this;
     alpha(): number;
-    alpha(alpha: number): Simulation<NodeDatum, LinkDatum>;
+    alpha(alpha: number): this;
     alphaMin(): number;
-    alphaMin(min: number): Simulation<NodeDatum, LinkDatum>;
+    alphaMin(min: number): this;
     alphaDecay(): number;
-    alphaDecay(decay: number): Simulation<NodeDatum, LinkDatum>;
+    alphaDecay(decay: number): this;
     alphaTarget(): number;
-    alphaTarget(target: number): Simulation<NodeDatum, LinkDatum>;
+    alphaTarget(target: number): this;
     velocityDecay(): number;
-    velocityDecay(decay: number): Simulation<NodeDatum, LinkDatum>;
+    velocityDecay(decay: number): this;
     force(name: string): Force<NodeDatum, LinkDatum>; // force names are arbitrary, so return type inference is not possible
-    force(name: string, force: null): Simulation<NodeDatum, LinkDatum>;
-    force(name: string, force: Force<NodeDatum, LinkDatum>): Simulation<NodeDatum, LinkDatum>;
+    force(name: string, force: null): this;
+    force(name: string, force: Force<NodeDatum, LinkDatum>): this;
     find(x: number, y: number, radius?: number): NodeDatum | undefined;
     on(typenames: 'tick' | 'end' | string): (this: Simulation<NodeDatum, LinkDatum>) => void;
-    on(typenames: 'tick' | 'end' | string, listener: null): Simulation<NodeDatum, LinkDatum>;
-    on(typenames: 'tick' | 'end' | string, listener: (this: this) => void): Simulation<NodeDatum, LinkDatum>;
+    on(typenames: 'tick' | 'end' | string, listener: null): this;
+    on(typenames: 'tick' | 'end' | string, listener: (this: this) => void): this;
 }
 
 export function forceSimulation<NodeDatum extends SimulationNodeDatum>(nodesData?: Array<NodeDatum>): Simulation<NodeDatum, undefined>;
@@ -73,9 +73,9 @@ export interface Force<NodeDatum extends SimulationNodeDatum, LinkDatum extends 
 
 export interface ForceCenter<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
     x(): number;
-    x(x: number): ForceCenter<NodeDatum>;
+    x(x: number): this;
     y(): number;
-    y(y: number): ForceCenter<NodeDatum>;
+    y(y: number): this;
 }
 
 export function forceCenter<NodeDatum extends SimulationNodeDatum>(x?: number, y?: number): ForceCenter<NodeDatum>;
@@ -84,12 +84,12 @@ export function forceCenter<NodeDatum extends SimulationNodeDatum>(x?: number, y
 
 export interface ForceCollide<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
     radius(): (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number;
-    radius(radius: number): ForceCollide<NodeDatum>;
-    radius(radius: (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number): ForceCollide<NodeDatum>;
+    radius(radius: number): this;
+    radius(radius: (node: NodeDatum, i: number, nodes: Array<NodeDatum>) => number): this;
     strength(): number;
-    strength(strength: number): ForceCollide<NodeDatum>;
+    strength(strength: number): this;
     iterations(): number;
-    iterations(iterations: number): ForceCollide<NodeDatum>;
+    iterations(iterations: number): this;
 }
 
 export function forceCollide<NodeDatum extends SimulationNodeDatum>(): ForceCollide<NodeDatum>;
@@ -100,17 +100,17 @@ export function forceCollide<NodeDatum extends SimulationNodeDatum>(radius: (nod
 
 export interface ForceLink<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> extends Force<NodeDatum, LinkDatum> {
     links(): Array<LinkDatum>;
-    links(links: Array<LinkDatum>): ForceLink<NodeDatum, LinkDatum>;
+    links(links: Array<LinkDatum>): this;
     id(): (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => (string | number);
-    id(id: (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => string): ForceLink<NodeDatum, LinkDatum>;
+    id(id: (node: NodeDatum, i: number, nodesData: Array<NodeDatum>) => string): this;
     distance(): (link: LinkDatum, i: number, links: Array<LinkDatum>) => number;
-    distance(distance: number): ForceLink<NodeDatum, LinkDatum>;
-    distance(distance: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): ForceLink<NodeDatum, LinkDatum>;
+    distance(distance: number): this;
+    distance(distance: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): this;
     strength(): (link: LinkDatum, i: number, links: Array<LinkDatum>) => number;
-    strength(strength: number): ForceLink<NodeDatum, LinkDatum>;
-    strength(strength: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): ForceLink<NodeDatum, LinkDatum>;
+    strength(strength: number): this;
+    strength(strength: (link: LinkDatum, i: number, links: Array<LinkDatum>) => number): this;
     iterations(): number;
-    iterations(iterations: number): ForceLink<NodeDatum, LinkDatum>;
+    iterations(iterations: number): this;
 }
 
 export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum extends SimulationLinkDatum<NodeDatum>>(): ForceLink<NodeDatum, LinksDatum>;
@@ -120,14 +120,14 @@ export function forceLink<NodeDatum extends SimulationNodeDatum, LinksDatum exte
 
 export interface ForceManyBody<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
     strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
-    strength(strength: number): ForceManyBody<NodeDatum>;
-    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceManyBody<NodeDatum>;
+    strength(strength: number): this;
+    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
     theta(): number;
-    theta(theta: number): ForceManyBody<NodeDatum>;
+    theta(theta: number): this;
     distanceMin(): number;
-    distanceMin(distance: number): ForceManyBody<NodeDatum>;
+    distanceMin(distance: number): this;
     distanceMax(): number;
-    distanceMax(distance: number): ForceManyBody<NodeDatum>;
+    distanceMax(distance: number): this;
 }
 
 export function forceManyBody<NodeDatum extends SimulationNodeDatum>(): ForceManyBody<NodeDatum>;
@@ -136,11 +136,11 @@ export function forceManyBody<NodeDatum extends SimulationNodeDatum>(): ForceMan
 
 export interface ForceX<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
     strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
-    strength(strength: number): ForceX<NodeDatum>;
-    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceX<NodeDatum>;
+    strength(strength: number): this;
+    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
     x(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
-    x(x: number): ForceX<NodeDatum>;
-    x(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceX<NodeDatum>;
+    x(x: number): this;
+    x(x: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
 }
 
 export function forceX<NodeDatum extends SimulationNodeDatum>(): ForceX<NodeDatum>;
@@ -149,11 +149,11 @@ export function forceX<NodeDatum extends SimulationNodeDatum>(x: (d: NodeDatum, 
 
 export interface ForceY<NodeDatum extends SimulationNodeDatum> extends Force<NodeDatum, any> {
     strength(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
-    strength(strength: number): ForceY<NodeDatum>;
-    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceY<NodeDatum>;
+    strength(strength: number): this;
+    strength(strength: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
     y(): (d: NodeDatum, i: number, data: Array<NodeDatum>) => number;
-    y(y: number): ForceY<NodeDatum>;
-    y(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): ForceY<NodeDatum>;
+    y(y: number): this;
+    y(y: (d: NodeDatum, i: number, data: Array<NodeDatum>) => number): this;
 }
 
 export function forceY<NodeDatum extends SimulationNodeDatum>(): ForceY<NodeDatum>;

--- a/src/d3-hsv/index.d.ts
+++ b/src/d3-hsv/index.d.ts
@@ -3,14 +3,14 @@
 // Definitions by: Yuri Feldman <https://github.com/arrayjam>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import {Color, RGBColor, ColorSpaceObject} from '../d3-color';
+import {Color, RGBColor, ColorSpaceObject, ColorCommonInstance} from '../d3-color';
 
 type ColorSpaceObjectWithHSV = ColorSpaceObject | HSVColor;
 
 export interface HSVColorFactory extends Function {
     (h: number, s: number, v: number, opacity?: number): HSVColor;
     (cssColorSpecifier: string): HSVColor;
-    (color: ColorSpaceObjectWithHSV): HSVColor;
+    (color: HSVColor | ColorSpaceObject | ColorCommonInstance): HSVColor;
 }
 
 export interface HSVColor extends Color {
@@ -18,8 +18,8 @@ export interface HSVColor extends Color {
     s: number;
     v: number;
     opacity: number;
-    brighter(k?: number): HSVColor;
-    darker(k?: number): HSVColor;
+    brighter(k?: number): this;
+    darker(k?: number): this;
     rgb(): RGBColor;
 }
 

--- a/src/d3-interpolate/index.d.ts
+++ b/src/d3-interpolate/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ColorSpaceObject } from '../d3-color';
+import { ColorCommonInstance, RGBColor } from '../d3-color';
 
 
 // --------------------------------------------------------------------------
@@ -20,7 +20,7 @@ export interface ZoomInterpolator extends Function {
 }
 
 export interface ColorGammaInterpolationFactory extends Function {
-    (a: string | ColorSpaceObject, b: string | ColorSpaceObject): ((t: number) => string);
+    (a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
     gamma(g: number): ColorGammaInterpolationFactory;
 }
 
@@ -39,7 +39,7 @@ export type ZoomView = [number, number, number];
 
 export function interpolate(a: any, b: null): ((t: number) => null);
 export function interpolate(a: number | { valueOf(): number }, b: number): ((t: number) => number);
-export function interpolate(a: any, b: ColorSpaceObject): ((t: number) => string);
+export function interpolate(a: any, b: ColorCommonInstance): ((t: number) => string);
 export function interpolate(a: Date, b: Date): ((t: number) => Date);
 export function interpolate(a: string | { toString(): string }, b: string): ((t: number) => string);
 export function interpolate<U extends Array<any>>(a: Array<any>, b: U): ((t: number) => U);
@@ -78,14 +78,14 @@ export function quantize<T>(interpolator: ((t: number) => T), n: number): Array<
 
 export var interpolateRgb: ColorGammaInterpolationFactory;
 
-export function interpolateRgbBasis(colors: Array<string | ColorSpaceObject>): ((t: number) => string);
-export function interpolateRgbBasisClosed(colors: Array<string | ColorSpaceObject>): ((t: number) => string);
+export function interpolateRgbBasis(colors: Array<string | ColorCommonInstance>): ((t: number) => string);
+export function interpolateRgbBasisClosed(colors: Array<string | ColorCommonInstance>): ((t: number) => string);
 
-export function interpolateHsl(a: string | ColorSpaceObject, b: string | ColorSpaceObject): ((t: number) => string);
-export function interpolateHslLong(a: string | ColorSpaceObject, b: string | ColorSpaceObject): ((t: number) => string);
-export function interpolateLab(a: string | ColorSpaceObject, b: string | ColorSpaceObject): ((t: number) => string);
-export function interpolateHcl(a: string | ColorSpaceObject, b: string | ColorSpaceObject): ((t: number) => string);
-export function interpolateHclLong(a: string | ColorSpaceObject, b: string | ColorSpaceObject): ((t: number) => string);
+export function interpolateHsl(a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
+export function interpolateHslLong(a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
+export function interpolateLab(a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
+export function interpolateHcl(a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
+export function interpolateHclLong(a: string | ColorCommonInstance, b: string | ColorCommonInstance): ((t: number) => string);
 export var interpolateCubehelix: ColorGammaInterpolationFactory;
 export var interpolateCubehelixLong: ColorGammaInterpolationFactory;
 

--- a/src/d3-quadtree/index.d.ts
+++ b/src/d3-quadtree/index.d.ts
@@ -24,23 +24,23 @@ export interface QuadtreeInternalNode<T> extends Array<QuadtreeInternalNode<T> |
 
 export interface Quadtree<T> {
     x(): (d: T) => number;
-    x(x: (d: T) => number): Quadtree<T>;
+    x(x: (d: T) => number): this;
     y(): (d: T) => number;
-    y(y: (d: T) => number): Quadtree<T>;
+    y(y: (d: T) => number): this;
     extent(): [[number, number], [number, number]] | undefined;
-    extent(extend: [[number, number], [number, number]]): Quadtree<T>;
-    cover(x: number, y: number): Quadtree<T>;
-    add(datum: T): Quadtree<T>;
-    addAll(data: Array<T>): Quadtree<T>;
-    remove(datum: T): Quadtree<T>;
-    removeAll(data: Array<T>): Quadtree<T>;
+    extent(extend: [[number, number], [number, number]]): this;
+    cover(x: number, y: number): this;
+    add(datum: T): this;
+    addAll(data: Array<T>): this;
+    remove(datum: T): this;
+    removeAll(data: Array<T>): this;
     copy(): Quadtree<T>;
     root(): QuadtreeInternalNode<T> | QuadtreeLeaf<T>;
     data(): Array<T>;
     size(): number;
     find(x: number, y: number, radius?: number): T | undefined;
-    visit(callback: (node: QuadtreeInternalNode<T> | QuadtreeLeaf<T>, x0: number, y0: number, x1: number, y1: number) => (void | boolean)): Quadtree<T>;
-    visitAfter(callback: (node: QuadtreeInternalNode<T> | QuadtreeLeaf<T>, x0: number, y0: number, x1: number, y1: number) => void): Quadtree<T>;
+    visit(callback: (node: QuadtreeInternalNode<T> | QuadtreeLeaf<T>, x0: number, y0: number, x1: number, y1: number) => (void | boolean)): this;
+    visitAfter(callback: (node: QuadtreeInternalNode<T> | QuadtreeLeaf<T>, x0: number, y0: number, x1: number, y1: number) => void): this;
 }
 
 

--- a/src/d3-request/index.d.ts
+++ b/src/d3-request/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-request module 1.0.1
 // Project: https://github.com/d3/d3-request/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Hugues Stefanski <https://github.com/Ledragon>, Tom Wanzek <https://github.com/tomwanzek> 
+// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Hugues Stefanski <https://github.com/Ledragon>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { DSVParsedArray, DSVRowString, DSVRowAny } from '../d3-dsv';
@@ -57,12 +57,12 @@ export interface Request {
 }
 
 export interface DsvRequest extends Request {
-    row<ParsedRow extends DSVRowAny>(value: (rawRow: DSVRowString, index?: number, columns?: Array<string>) => ParsedRow): DsvRequest;
+    row<ParsedRow extends DSVRowAny>(value: (rawRow: DSVRowString, index: number, columns: Array<string>) => ParsedRow): DsvRequest;
 }
 
 export function csv(url: string): DsvRequest;
 export function csv(url: string, callback: (this: DsvRequest, error: any, d: DSVParsedArray<DSVRowString>) => void): DsvRequest;
-export function csv<ParsedRow extends DSVRowAny>(url: string, row: (rawRow: DSVRowString, index?: number, columns?: Array<string>) => ParsedRow, callback: (this: DsvRequest, error: any, d: DSVParsedArray<ParsedRow>) => void): DsvRequest;
+export function csv<ParsedRow extends DSVRowAny>(url: string, row: (rawRow: DSVRowString, index: number, columns: Array<string>) => ParsedRow, callback: (this: DsvRequest, error: any, d: DSVParsedArray<ParsedRow>) => void): DsvRequest;
 
 export function html(url: string): Request;
 export function html(url: string, callback: (this: Request, error: any, d: DocumentFragment) => void): Request;
@@ -78,7 +78,7 @@ export function text(url: string, callback: (this: Request, error: any, d: strin
 
 export function tsv(url: string): DsvRequest;
 export function tsv(url: string, callback: (this: DsvRequest, error: any, d: DSVParsedArray<DSVRowString>) => void): DsvRequest;
-export function tsv<ParsedRow extends DSVRowAny>(url: string, row: (rawRow: DSVRowString, index?: number, columns?: Array<string>) => ParsedRow, callback: (this: DsvRequest, error: any, d: DSVParsedArray<ParsedRow>) => void): DsvRequest;
+export function tsv<ParsedRow extends DSVRowAny>(url: string, row: (rawRow: DSVRowString, index: number, columns: Array<string>) => ParsedRow, callback: (this: DsvRequest, error: any, d: DSVParsedArray<ParsedRow>) => void): DsvRequest;
 
 export function xml(url: string): Request;
 export function xml(url: string, callback: (this: Request, error: any, d: any) => void): Request;

--- a/src/d3-scale/index.d.ts
+++ b/src/d3-scale/index.d.ts
@@ -28,22 +28,22 @@ export interface ScaleLinear<Range, Output> {
      */
     invert(value: number | { valueOf(): number }): number;
     domain(): Array<number>;
-    domain(domain: Array<number | { valueOf(): number }>): ScaleLinear<Range, Output>;
+    domain(domain: Array<number | { valueOf(): number }>): this;
     range(): Array<Range>;
-    range(range: Array<Range>): ScaleLinear<Range, Output>;
+    range(range: Array<Range>): this;
     /**
      * Important: While value should come out of range R, this is method is only applicable to
      * values that can be coerced to numeric.
      */
-    rangeRound(range: Array<number | { valueOf(): number }>): ScaleLinear<Range, Output>;
+    rangeRound(range: Array<number | { valueOf(): number }>): this;
     clamp(): boolean;
     clamp(clamp: boolean): ScaleLinear<Range, Output>;
     interpolate(): InterpolatorFactory<any, any>;
-    interpolate(interpolate: InterpolatorFactory<Range, Output>): ScaleLinear<Range, Output>;
+    interpolate(interpolate: InterpolatorFactory<Range, Output>): this;
     interpolate<NewOutput>(interpolate: InterpolatorFactory<Range, NewOutput>): ScaleLinear<Range, NewOutput>;
     ticks(count?: number): Array<number>;
     tickFormat(count?: number, specifier?: string): ((d: number | { valueOf(): number }) => string);
-    nice(count?: number): ScaleLinear<Range, Output>;
+    nice(count?: number): this;
     copy(): ScaleLinear<Range, Output>;
 }
 
@@ -64,26 +64,26 @@ export interface ScalePower<Range, Output> {
      */
     invert(value: number | { valueOf(): number }): number;
     domain(): Array<number>;
-    domain(domain: Array<number | { valueOf(): number }>): ScalePower<Range, Output>;
+    domain(domain: Array<number | { valueOf(): number }>): this;
     range(): Array<Range>;
-    range(range: Array<Range>): ScalePower<Range, Output>;
+    range(range: Array<Range>): this;
     /**
      * Important: While value should come out of range R, this is method is only applicable to
      * values that can be coerced to numeric.
      */
-    rangeRound(range: Array<number | { valueOf(): number }>): ScalePower<Range, Output>;
+    rangeRound(range: Array<number | { valueOf(): number }>): this;
     clamp(): boolean;
-    clamp(clamp: boolean): ScalePower<Range, Output>;
+    clamp(clamp: boolean): this;
     interpolate(): InterpolatorFactory<any, any>;
-    interpolate(interpolate: InterpolatorFactory<Range, Output>): ScalePower<Range, Output>;
+    interpolate(interpolate: InterpolatorFactory<Range, Output>): this;
     interpolate<NewOutput>(interpolate: InterpolatorFactory<Range, NewOutput>): ScalePower<Range, NewOutput>;
     ticks(count?: number): Array<number>;
     tickFormat(count?: number, specifier?: string): ((d: number | { valueOf(): number }) => string);
-    nice(count?: number): ScalePower<Range, Output>;
+    nice(count?: number): this;
     copy(): ScalePower<Range, Output>;
 
     exponent(): number;
-    exponent(exponent: number): ScalePower<Range, Output>;
+    exponent(exponent: number): this;
 }
 
 export function scalePow(): ScalePower<number, number>;
@@ -107,26 +107,26 @@ export interface ScaleLogarithmic<Range, Output> {
      */
     invert(value: number | { valueOf(): number }): number;
     domain(): Array<number>;
-    domain(domain: Array<number | { valueOf(): number }>): ScaleLogarithmic<Range, Output>;
+    domain(domain: Array<number | { valueOf(): number }>): this;
     range(): Array<Range>;
-    range(range: Array<Range>): ScaleLogarithmic<Range, Output>;
+    range(range: Array<Range>): this;
     /**
      * Important: While value should come out of range R, this is method is only applicable to
      * values that can be coerced to numeric.
      */
-    rangeRound(range: Array<number | { valueOf(): number }>): ScaleLogarithmic<Range, Output>;
+    rangeRound(range: Array<number | { valueOf(): number }>): this;
     clamp(): boolean;
-    clamp(clamp: boolean): ScaleLogarithmic<Range, Output>;
+    clamp(clamp: boolean): this;
     interpolate(): InterpolatorFactory<any, any>;
-    interpolate(interpolate: InterpolatorFactory<Range, Output>): ScaleLogarithmic<Range, Output>;
+    interpolate(interpolate: InterpolatorFactory<Range, Output>): this;
     interpolate<NewOutput>(interpolate: InterpolatorFactory<Range, NewOutput>): ScaleLogarithmic<Range, NewOutput>;
     ticks(count?: number): Array<number>;
     tickFormat(count?: number, specifier?: string): ((d: number | { valueOf(): number }) => string);
-    nice(count?: number): ScaleLogarithmic<Range, Output>;
+    nice(count?: number): this;
     copy(): ScaleLogarithmic<Range, Output>;
 
     base(): number;
-    base(base: number): ScaleLogarithmic<Range, Output>;
+    base(base: number): this;
 }
 
 export function scaleLog(): ScaleLogarithmic<number, number>;
@@ -146,12 +146,12 @@ export interface ScaleIdentity {
      */
     invert(value: number | { valueOf(): number }): number;
     domain(): Array<number>;
-    domain(domain: Array<number | { valueOf(): number }>): ScaleIdentity;
+    domain(domain: Array<number | { valueOf(): number }>): this;
     range(): Array<number>;
-    range(range: Array<Range | { valueOf(): number }>): ScaleIdentity;
+    range(range: Array<Range | { valueOf(): number }>): this;
     ticks(count?: number): Array<number>;
     tickFormat(count?: number, specifier?: string): ((d: number | { valueOf(): number }) => string);
-    nice(count?: number): ScaleIdentity;
+    nice(count?: number): this;
     copy(): ScaleIdentity;
 }
 
@@ -170,18 +170,18 @@ export interface ScaleTime<Range, Output> {
      */
     invert(value: number | { valueOf(): number }): Date;
     domain(): Array<Date>;
-    domain(domain: Array<Date>): ScaleTime<Range, Output>;
+    domain(domain: Array<Date>): this;
     range(): Array<Range>;
-    range(range: Array<Range>): ScaleTime<Range, Output>;
+    range(range: Array<Range>): this;
     /**
      * Important: While value should come out of range R, this is method is only applicable to
      * values that can be coerced to numeric.
      */
-    rangeRound(range: Array<number | { valueOf(): number }>): ScaleTime<Range, Output>;
+    rangeRound(range: Array<number | { valueOf(): number }>): this;
     clamp(): boolean;
-    clamp(clamp: boolean): ScaleTime<Range, Output>;
+    clamp(clamp: boolean): this;
     interpolate(): InterpolatorFactory<any, any>;
-    interpolate(interpolate: InterpolatorFactory<Range, Output>): ScaleTime<Range, Output>;
+    interpolate(interpolate: InterpolatorFactory<Range, Output>): this;
     interpolate<NewOutput>(interpolate: InterpolatorFactory<Range, NewOutput>): ScaleTime<Range, NewOutput>;
     ticks(): Array<Date>;
     ticks(count: number): Array<Date>;
@@ -189,9 +189,9 @@ export interface ScaleTime<Range, Output> {
     tickFormat(): ((d: Date) => string);
     tickFormat(count: number, specifier?: string): ((d: Date) => string);
     tickFormat(interval: TimeInterval, specifier?: string): ((d: Date) => string);
-    nice(): ScaleTime<Range, Output>;
-    nice(count: number): ScaleTime<Range, Output>;
-    nice(interval: CountableTimeInterval, step?: number): ScaleTime<Range, Output>;
+    nice(): this;
+    nice(count: number): this;
+    nice(interval: CountableTimeInterval, step?: number): this;
     copy(): ScaleTime<Range, Output>;
 }
 
@@ -211,11 +211,11 @@ export function scaleUtc<Range, Output>(): ScaleTime<Range, Output>;
 export interface ScaleSequential<Output> {
     (value: number | { valueOf(): number }): Output;
     domain(): [number, number];
-    domain(domain: [number | { valueOf(): number }, number | { valueOf(): number }]): ScaleSequential<Output>;
+    domain(domain: [number | { valueOf(): number }, number | { valueOf(): number }]): this;
     clamp(): boolean;
-    clamp(clamp: boolean): ScaleSequential<Output>;
+    clamp(clamp: boolean): this;
     interpolator(): ((t: number) => Output);
-    interpolator(interpolator: ((t: number) => Output)): ScaleSequential<Output>;
+    interpolator(interpolator: ((t: number) => Output)): this;
     interpolator<NewOutput>(interpolator: ((t: number) => NewOutput)): ScaleSequential<NewOutput>;
     copy(): ScaleSequential<Output>;
 }
@@ -255,12 +255,12 @@ export interface ScaleQuantize<Range> {
      */
     invertExtent(value: Range): [number, number];
     domain(): [number, number];
-    domain(domain: [number | { valueOf(): number }, number | { valueOf(): number }]): ScaleQuantize<Range>;
+    domain(domain: [number | { valueOf(): number }, number | { valueOf(): number }]): this;
     range(): Array<Range>;
-    range(range: Array<Range>): ScaleQuantize<Range>;
+    range(range: Array<Range>): this;
     ticks(count?: number): Array<number>;
     tickFormat(count?: number, specifier?: string): ((d: number | { valueOf(): number }) => string);
-    nice(count?: number): ScaleQuantize<Range>;
+    nice(count?: number): this;
     copy(): ScaleQuantize<Range>;
 }
 
@@ -275,9 +275,9 @@ export interface ScaleQuantile<Range> {
     (value: number | { valueOf(): number }): Range;
     invertExtent(value: Range): [number, number];
     domain(): Array<number>;
-    domain(domain: Array<number | { valueOf(): number }>): ScaleQuantile<Range>;
+    domain(domain: Array<number | { valueOf(): number }>): this;
     range(): Array<Range>;
-    range(range: Array<Range>): ScaleQuantile<Range>;
+    range(range: Array<Range>): this;
     quantiles(): Array<number>;
     copy(): ScaleQuantile<Range>;
 }
@@ -298,9 +298,9 @@ export interface ScaleThreshold<Domain extends number | string | Date, Range> {
      */
     invertExtent(value: Range): [Domain, Domain] | [undefined, Domain] | [Domain, undefined] | [undefined, undefined];
     domain(): Array<Domain>;
-    domain(domain: Array<Domain>): ScaleThreshold<Domain, Range>;
+    domain(domain: Array<Domain>): this;
     range(): Array<Range>;
-    range(range: Array<Range>): ScaleThreshold<Domain, Range>;
+    range(range: Array<Range>): this;
     copy(): ScaleThreshold<Domain, Range>;
 }
 
@@ -315,11 +315,11 @@ export function scaleThreshold<Domain extends number | string | Date, Range>(): 
 export interface ScaleOrdinal<Domain extends { toString(): string }, Range> {
     (x: Domain): Range;
     domain(): Array<Domain>;
-    domain(domain: Array<Domain>): ScaleOrdinal<Domain, Range>;
+    domain(domain: Array<Domain>): this;
     range(): Array<Range>;
-    range(range: Array<Range>): ScaleOrdinal<Domain, Range>;
+    range(range: Array<Range>): this;
     unknown(): Range | { name: 'implicit' };
-    unknown(value: Range | { name: 'implicit' }): ScaleOrdinal<Domain, Range>;
+    unknown(value: Range | { name: 'implicit' }): this;
     copy(): ScaleOrdinal<Domain, Range>;
 }
 
@@ -336,16 +336,16 @@ export const scaleImplicit: { name: 'implicit' };
 export interface ScaleBand<Domain extends { toString(): string }> {
     (x: Domain): number | undefined;
     domain(): Array<Domain>;
-    domain(domain: Array<Domain>): ScaleBand<Domain>;
+    domain(domain: Array<Domain>): this;
     range(): [number, number];
-    range(range: [number | { valueOf(): number }, number | { valueOf(): number }]): ScaleBand<Domain>;
-    rangeRound(range: [number | { valueOf(): number }, number | { valueOf(): number }]): ScaleBand<Domain>;
+    range(range: [number | { valueOf(): number }, number | { valueOf(): number }]): this;
+    rangeRound(range: [number | { valueOf(): number }, number | { valueOf(): number }]): this;
     round(): boolean;
-    round(round: boolean): ScaleBand<Domain>;
+    round(round: boolean): this;
     paddingInner(): number;
-    paddingInner(padding: number): ScaleBand<Domain>;
+    paddingInner(padding: number): this;
     paddingOuter(): number;
-    paddingOuter(padding: number): ScaleBand<Domain>;
+    paddingOuter(padding: number): this;
     /**
      * Returns the inner padding.
      */
@@ -353,9 +353,9 @@ export interface ScaleBand<Domain extends { toString(): string }> {
     /**
      * A convenience method for setting the inner and outer padding to the same padding value.
      */
-    padding(padding: number): ScaleBand<Domain>;
+    padding(padding: number): this;
     align(): number;
-    align(align: number): ScaleBand<Domain>;
+    align(align: number): this;
     bandwidth(): number;
     step(): number;
     copy(): ScaleBand<Domain>;
@@ -371,12 +371,12 @@ export function scaleBand<Domain extends { toString(): string }>(): ScaleBand<Do
 export interface ScalePoint<Domain extends { toString(): string }> {
     (x: Domain): number | undefined;
     domain(): Array<Domain>;
-    domain(domain: Array<Domain>): ScalePoint<Domain>;
+    domain(domain: Array<Domain>): this;
     range(): [number, number];
-    range(range: [number | { valueOf(): number }, number | { valueOf(): number }]): ScalePoint<Domain>;
-    rangeRound(range: [number | { valueOf(): number }, number | { valueOf(): number }]): ScalePoint<Domain>;
+    range(range: [number | { valueOf(): number }, number | { valueOf(): number }]): this;
+    rangeRound(range: [number | { valueOf(): number }, number | { valueOf(): number }]): this;
     round(): boolean;
-    round(round: boolean): ScalePoint<Domain>;
+    round(round: boolean): this;
     /**
      * Returns the current outer padding which defaults to 0.
      * The outer padding determines the ratio of the range that is reserved for blank space
@@ -388,9 +388,9 @@ export interface ScalePoint<Domain extends { toString(): string }> {
      * The outer padding determines the ratio of the range that is reserved for blank space
      * before the first point and after the last point.
      */
-    padding(padding: number): ScalePoint<Domain>;
+    padding(padding: number): this;
     align(): number;
-    align(align: number): ScalePoint<Domain>;
+    align(align: number): this;
     bandwidth(): number;
     step(): number;
     copy(): ScalePoint<Domain>;

--- a/src/d3-scale/index.d.ts
+++ b/src/d3-scale/index.d.ts
@@ -209,7 +209,7 @@ export function scaleUtc<Range, Output>(): ScaleTime<Range, Output>;
 
 
 export interface ScaleSequential<Output> {
-    (value: number): Output;
+    (value: number | { valueOf(): number }): Output;
     domain(): [number, number];
     domain(domain: [number | { valueOf(): number }, number | { valueOf(): number }]): ScaleSequential<Output>;
     clamp(): boolean;

--- a/src/d3-selection-multi/index.d.ts
+++ b/src/d3-selection-multi/index.d.ts
@@ -3,14 +3,12 @@
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import {Selection, BaseType, ArrayLike} from '../d3-selection';
+import {Selection, BaseType, ArrayLike, ValueFn} from '../d3-selection';
 import {Transition} from '../d3-transition';
 
-// Callback type for selections and transitions
-type ValueFn<Element, Datum, Result> = (this: Element, datum: Datum, index: number, groups: Array<Element> | ArrayLike<Element>) => Result;
 
 // An object mapping attribute (or style or property) names to value accessors
-type ValueMap<Element, Datum> = { [key: string]: number | string | boolean | null | ValueFn<Element, Datum, number | string | boolean | null> };
+export type ValueMap<Element, Datum> = { [key: string]: number | string | boolean | null | ValueFn<Element, Datum, number | string | boolean | null> };
 
 declare module '../d3-selection' {
     export interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {

--- a/src/d3-selection/index.d.ts
+++ b/src/d3-selection/index.d.ts
@@ -115,31 +115,31 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     // Modifying -------------------------------
 
     attr(name: string): string;
-    attr(name: string, value: null): Selection<GElement, Datum, PElement, PDatum>;
-    attr(name: string, value: string | number | boolean): Selection<GElement, Datum, PElement, PDatum>;
-    attr(name: string, value: ValueFn<GElement, Datum, string | number | boolean>): Selection<GElement, Datum, PElement, PDatum>;
+    attr(name: string, value: null): this;
+    attr(name: string, value: string | number | boolean): this;
+    attr(name: string, value: ValueFn<GElement, Datum, string | number | boolean>): this;
 
     classed(name: string): boolean;
-    classed(name: string, value: boolean): Selection<GElement, Datum, PElement, PDatum>;
-    classed(name: string, value: ValueFn<GElement, Datum, boolean>): Selection<GElement, Datum, PElement, PDatum>;
+    classed(name: string, value: boolean): this;
+    classed(name: string, value: ValueFn<GElement, Datum, boolean>): this;
 
     style(name: string): string;
-    style(name: string, value: null): Selection<GElement, Datum, PElement, PDatum>;
-    style(name: string, value: string | number | boolean, priority?: null | 'important'): Selection<GElement, Datum, PElement, PDatum>;
-    style(name: string, value: ValueFn<GElement, Datum, string | number | boolean>, priority?: null | 'important'): Selection<GElement, Datum, PElement, PDatum>;
+    style(name: string, value: null): this;
+    style(name: string, value: string | number | boolean, priority?: null | 'important'): this;
+    style(name: string, value: ValueFn<GElement, Datum, string | number | boolean>, priority?: null | 'important'): this;
 
     property(name: string): any;
-    property(name: string, value: ValueFn<GElement, Datum, any>): Selection<GElement, Datum, PElement, PDatum>;
-    property(name: string, value: null): Selection<GElement, Datum, PElement, PDatum>;
-    property(name: string, value: any): Selection<GElement, Datum, PElement, PDatum>;
+    property(name: string, value: ValueFn<GElement, Datum, any>): this;
+    property(name: string, value: null): this;
+    property(name: string, value: any): this;
 
     text(): string;
-    text(value: string | number | boolean): Selection<GElement, Datum, PElement, PDatum>;
-    text(value: ValueFn<GElement, Datum, string | number | boolean>): Selection<GElement, Datum, PElement, PDatum>;
+    text(value: string | number | boolean): this;
+    text(value: ValueFn<GElement, Datum, string | number | boolean>): this;
 
     html(): string;
-    html(value: string): Selection<GElement, Datum, PElement, PDatum>;
-    html(value: ValueFn<GElement, Datum, string>): Selection<GElement, Datum, PElement, PDatum>;
+    html(value: string): this;
+    html(value: ValueFn<GElement, Datum, string>): this;
 
     append<ChildElement extends BaseType>(type: string): Selection<ChildElement, Datum, PElement, PDatum>;
     append<ChildElement extends BaseType>(type: ValueFn<GElement, Datum, ChildElement>): Selection<ChildElement, Datum, PElement, PDatum>;
@@ -153,22 +153,22 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      * Removes the selected elements from the document.
      * Returns this selection (the removed elements) which are now detached from the DOM.
      */
-    remove(): Selection<GElement, Datum, PElement, PDatum>;
+    remove(): this;
 
     merge(other: Selection<GElement, Datum, PElement, PDatum>): Selection<GElement, Datum, PElement, PDatum>;
 
-    filter(selector: string): Selection<GElement, Datum, PElement, PDatum>;
-    filter(selector: ValueFn<GElement, Datum, boolean>): Selection<GElement, Datum, PElement, PDatum>;
+    filter(selector: string): this;
+    filter(selector: ValueFn<GElement, Datum, boolean>): this;
 
 
 
-    sort(comparator?: (a: Datum, b: Datum) => number): Selection<GElement, Datum, PElement, PDatum>;
+    sort(comparator?: (a: Datum, b: Datum) => number): this;
 
-    order(): Selection<GElement, Datum, PElement, PDatum>;
+    order(): this;
 
-    raise(): Selection<GElement, Datum, PElement, PDatum>;
+    raise(): this;
 
-    lower(): Selection<GElement, Datum, PElement, PDatum>;
+    lower(): this;
 
 
     // Data Join ---------------------------------
@@ -192,18 +192,18 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     // Event Handling -------------------
 
     on(type: string): ValueFn<GElement, Datum, void>;
-    on(type: string, listener: null): Selection<GElement, Datum, PElement, PDatum>;
-    on(type: string, listener: ValueFn<GElement, Datum, void>, capture?: boolean): Selection<GElement, Datum, PElement, PDatum>;
+    on(type: string, listener: null): this;
+    on(type: string, listener: ValueFn<GElement, Datum, void>, capture?: boolean): this;
 
 
-    dispatch(type: string, parameters?: CustomEventParameters): Selection<GElement, Datum, PElement, PDatum>;
-    dispatch(type: string, parameters?: ValueFn<GElement, Datum, CustomEventParameters>): Selection<GElement, Datum, PElement, PDatum>;
+    dispatch(type: string, parameters?: CustomEventParameters): this;
+    dispatch(type: string, parameters?: ValueFn<GElement, Datum, CustomEventParameters>): this;
 
     // Control Flow ----------------------
 
-    each(valueFn: ValueFn<GElement, Datum, void>): Selection<GElement, Datum, PElement, PDatum>;
+    each(valueFn: ValueFn<GElement, Datum, void>): this;
 
-    call(func: (selection: Selection<GElement, Datum, PElement, PDatum>, ...args: any[]) => void, ...args: any[]): Selection<GElement, Datum, PElement, PDatum>;
+    call(func: (selection: Selection<GElement, Datum, PElement, PDatum>, ...args: any[]) => void, ...args: any[]): this;
 
     empty(): boolean;
 

--- a/src/d3-selection/index.d.ts
+++ b/src/d3-selection/index.d.ts
@@ -21,7 +21,7 @@ export interface ArrayLike<T> {
     [index: number]: T;
 }
 
-// TODO: Review Use for enter()
+
 export interface EnterElement {
     ownerDocument: Document;
     namespaceURI: string;
@@ -56,6 +56,11 @@ export type CustomEventParameters = {
     detail: any;
 }
 
+/**
+ * Callback type for selections and transitions
+ */
+export type ValueFn<Element, Datum, Result> = (this: Element, datum: Datum, index: number, groups: Array<Element> | ArrayLike<Element>) => Result;
+
 
 /**
  * TransitionLike is a helper interface to represent a quasi-Transition, without specifying the full Transition  interface in this file.
@@ -70,9 +75,9 @@ export type CustomEventParameters = {
 export interface TransitionLike<GElement extends BaseType, Datum> {
     selection(): Selection<GElement, Datum, any, any>;
     on(type: string, listener: null): TransitionLike<GElement, Datum>;
-    on(type: string, listener: (this: GElement, datum: Datum, index: number, group: Array<GElement> | ArrayLike<GElement>) => any): TransitionLike<GElement, Datum>;
+    on(type: string, listener: ValueFn<GElement, Datum, void>): TransitionLike<GElement, Datum>;
     tween(name: string, tweenFn: null): TransitionLike<GElement, Datum>;
-    tween(name: string, tweenFn: (this: GElement, datum?: Datum, i?: number, group?: GElement[] | ArrayLike<GElement>) => ((t: number) => void)): TransitionLike<GElement, Datum>;
+    tween(name: string, tweenFn: ValueFn<GElement, Datum, ((t: number) => void)>): TransitionLike<GElement, Datum>;
 }
 
 
@@ -100,50 +105,49 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
 
     select<DescElement extends BaseType>(selector: string): Selection<DescElement, Datum, PElement, PDatum>;
     select<DescElement extends BaseType>(selector: null): Selection<null, undefined, PElement, PDatum>; // _groups are set to empty array, first generic type is set to null by convention
-    select<DescElement extends BaseType>(selector: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => DescElement): Selection<DescElement, Datum, PElement, PDatum>;
+    select<DescElement extends BaseType>(selector: ValueFn<GElement, Datum, DescElement>): Selection<DescElement, Datum, PElement, PDatum>;
 
     selectAll(): Selection<null, undefined, GElement, Datum>; // _groups are set to empty array, first generic type is set to null by convention
     selectAll(selector: null): Selection<null, undefined, GElement, Datum>; // _groups are set to empty array, first generic type is set to null by convention
     selectAll<DescElement extends BaseType, OldDatum>(selector: string): Selection<DescElement, OldDatum, GElement, Datum>;
-    selectAll<DescElement extends BaseType, OldDatum>(selector: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => (Array<DescElement> | ArrayLike<DescElement>)): Selection<DescElement, OldDatum, GElement, Datum>;
+    selectAll<DescElement extends BaseType, OldDatum>(selector: ValueFn<GElement, Datum, Array<DescElement> | ArrayLike<DescElement>>): Selection<DescElement, OldDatum, GElement, Datum>;
 
     // Modifying -------------------------------
 
     attr(name: string): string;
     attr(name: string, value: null): Selection<GElement, Datum, PElement, PDatum>;
     attr(name: string, value: string | number | boolean): Selection<GElement, Datum, PElement, PDatum>;
-    attr(name: string, value: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => (string | number | boolean)): Selection<GElement, Datum, PElement, PDatum>;
+    attr(name: string, value: ValueFn<GElement, Datum, string | number | boolean>): Selection<GElement, Datum, PElement, PDatum>;
 
     classed(name: string): boolean;
     classed(name: string, value: boolean): Selection<GElement, Datum, PElement, PDatum>;
-    classed(name: string, value: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => boolean): Selection<GElement, Datum, PElement, PDatum>;
+    classed(name: string, value: ValueFn<GElement, Datum, boolean>): Selection<GElement, Datum, PElement, PDatum>;
 
     style(name: string): string;
     style(name: string, value: null): Selection<GElement, Datum, PElement, PDatum>;
     style(name: string, value: string | number | boolean, priority?: null | 'important'): Selection<GElement, Datum, PElement, PDatum>;
-    style(name: string, value: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => (string | number | boolean), priority?: null | 'important'): Selection<GElement, Datum, PElement, PDatum>;
+    style(name: string, value: ValueFn<GElement, Datum, string | number | boolean>, priority?: null | 'important'): Selection<GElement, Datum, PElement, PDatum>;
 
     property(name: string): any;
-    property(name: string, value: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => any): Selection<GElement, Datum, PElement, PDatum>;
+    property(name: string, value: ValueFn<GElement, Datum, any>): Selection<GElement, Datum, PElement, PDatum>;
     property(name: string, value: null): Selection<GElement, Datum, PElement, PDatum>;
     property(name: string, value: any): Selection<GElement, Datum, PElement, PDatum>;
 
     text(): string;
     text(value: string | number | boolean): Selection<GElement, Datum, PElement, PDatum>;
-    text(value: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => (string | number | boolean)): Selection<GElement, Datum, PElement, PDatum>;
+    text(value: ValueFn<GElement, Datum, string | number | boolean>): Selection<GElement, Datum, PElement, PDatum>;
 
     html(): string;
     html(value: string): Selection<GElement, Datum, PElement, PDatum>;
-    html(value: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => string): Selection<GElement, Datum, PElement, PDatum>;
+    html(value: ValueFn<GElement, Datum, string>): Selection<GElement, Datum, PElement, PDatum>;
 
     append<ChildElement extends BaseType>(type: string): Selection<ChildElement, Datum, PElement, PDatum>;
-    append<ChildElement extends BaseType>(type: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => ChildElement): Selection<ChildElement, Datum, PElement, PDatum>;
+    append<ChildElement extends BaseType>(type: ValueFn<GElement, Datum, ChildElement>): Selection<ChildElement, Datum, PElement, PDatum>;
 
     insert<ChildElement extends BaseType>(type: string, before: string): Selection<ChildElement, Datum, PElement, PDatum>;
-    insert<ChildElement extends BaseType>(type: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => ChildElement, before: string): Selection<ChildElement, Datum, PElement, PDatum>;
-    insert<ChildElement extends BaseType>(type: string, before: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => BaseType): Selection<ChildElement, Datum, PElement, PDatum>;
-    insert<ChildElement extends BaseType>(type: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => ChildElement,
-        before: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => BaseType): Selection<ChildElement, Datum, PElement, PDatum>;
+    insert<ChildElement extends BaseType>(type: ValueFn<GElement, Datum, ChildElement>, before: string): Selection<ChildElement, Datum, PElement, PDatum>;
+    insert<ChildElement extends BaseType>(type: string, before: ValueFn<GElement, Datum, BaseType>): Selection<ChildElement, Datum, PElement, PDatum>;
+    insert<ChildElement extends BaseType>(type: ValueFn<GElement, Datum, ChildElement>, before: ValueFn<GElement, Datum, BaseType>): Selection<ChildElement, Datum, PElement, PDatum>;
 
     /**
      * Removes the selected elements from the document.
@@ -154,7 +158,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     merge(other: Selection<GElement, Datum, PElement, PDatum>): Selection<GElement, Datum, PElement, PDatum>;
 
     filter(selector: string): Selection<GElement, Datum, PElement, PDatum>;
-    filter(selector: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => boolean): Selection<GElement, Datum, PElement, PDatum>;
+    filter(selector: ValueFn<GElement, Datum, boolean>): Selection<GElement, Datum, PElement, PDatum>;
 
 
 
@@ -171,42 +175,33 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
 
     datum(): Datum;
     datum(value: null): Selection<GElement, undefined, PElement, PDatum>;
-    datum<NewDatum>(value: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => NewDatum): Selection<GElement, NewDatum, PElement, PDatum>;
+    datum<NewDatum>(value: ValueFn<GElement, Datum, NewDatum>): Selection<GElement, NewDatum, PElement, PDatum>;
     datum<NewDatum>(value: NewDatum): Selection<GElement, NewDatum, PElement, PDatum>;
 
     data(): Datum[];
-    data<NewDatum>(
-        data: Array<NewDatum>,
-        key?: (this: GElement | PElement, datum?: Datum | NewDatum, index?: number, group?: Array<GElement | PElement> | ArrayLike<GElement | PElement>) => string
-    ): Selection<GElement, NewDatum, PElement, PDatum>;
-    data<NewDatum>(
-        data: (this: PElement, datum?: PDatum, index?: number, group?: Array<PElement> | ArrayLike<PElement>) => Array<NewDatum>,
-        key?: (this: GElement | PElement, datum?: Datum | NewDatum, index?: number, group?: Array<GElement | PElement> | ArrayLike<GElement | PElement>) => string
-    ): Selection<GElement, NewDatum, PElement, PDatum>;
+    data<NewDatum>(data: Array<NewDatum>, key?: ValueFn<GElement | PElement, Datum | NewDatum, string>): Selection<GElement, NewDatum, PElement, PDatum>;
+    data<NewDatum>(data: ValueFn<PElement, PDatum, Array<NewDatum>>, key?: ValueFn<GElement | PElement, Datum | NewDatum, string>): Selection<GElement, NewDatum, PElement, PDatum>;
 
-    // TODO: Enter Selection returns GElements of type EnterNode, which do not meet the minimum interface of BaseType = Element
-    // HACK: Keep enter() selection 'as-if' they  are of type GElement, while overly permissive, this may be of little practical relevance,
-    // given that the normal next step is an .append(...), which would address the matter
     enter(): Selection<EnterElement, Datum, PElement, PDatum>;
 
-    // TODO: Review this: The type Datum on the exit items is actually of the type prior to calling data(...), as by definition, no new data of type NewDatum exists for these
+    // The type Datum on the exit items is actually of the type prior to calling data(...), as by definition, no new data of type NewDatum exists for these
     // elements. Due to the chaining, .data(...).exit(...), however, the definition would imply that the exit group elements have assumed the NewDatum type.
     // This seems to imply the following workaroud: Recast the exit Selection to OldDatum, if needed, or ommit and allow exit group elements to be of type any.
     exit<OldDatum>(): Selection<GElement, OldDatum, PElement, PDatum>;
 
     // Event Handling -------------------
 
-    on(type: string): (this: GElement, datum: Datum, index: number, group: Array<GElement> | ArrayLike<GElement>) => void;
+    on(type: string): ValueFn<GElement, Datum, void>;
     on(type: string, listener: null): Selection<GElement, Datum, PElement, PDatum>;
-    on(type: string, listener: (this: GElement, datum: Datum, index: number, group: Array<GElement> | ArrayLike<GElement>) => void, capture?: boolean): Selection<GElement, Datum, PElement, PDatum>;
+    on(type: string, listener: ValueFn<GElement, Datum, void>, capture?: boolean): Selection<GElement, Datum, PElement, PDatum>;
 
 
     dispatch(type: string, parameters?: CustomEventParameters): Selection<GElement, Datum, PElement, PDatum>;
-    dispatch(type: string, parameters?: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => CustomEventParameters): Selection<GElement, Datum, PElement, PDatum>;
+    dispatch(type: string, parameters?: ValueFn<GElement, Datum, CustomEventParameters>): Selection<GElement, Datum, PElement, PDatum>;
 
     // Control Flow ----------------------
 
-    each(valueFn: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => void): Selection<GElement, Datum, PElement, PDatum>;
+    each(valueFn: ValueFn<GElement, Datum, void>): Selection<GElement, Datum, PElement, PDatum>;
 
     call(func: (selection: Selection<GElement, Datum, PElement, PDatum>, ...args: any[]) => void, ...args: any[]): Selection<GElement, Datum, PElement, PDatum>;
 

--- a/src/d3-shape/index.d.ts
+++ b/src/d3-shape/index.d.ts
@@ -291,7 +291,7 @@ export interface SymbolType {
 
 
 export interface Symbol<This, Datum> {
-    (this: This, d: Datum, ...args: any[]): undefined | string;
+    (this: This, d?: Datum, ...args: any[]): undefined | string;
     size(): (this: This, d: Datum, ...args: any[]) => number;
     size(size: number): this;
     size(size: (this: This, d: Datum, ...args: any[]) => number): this;

--- a/src/d3-shape/index.d.ts
+++ b/src/d3-shape/index.d.ts
@@ -19,26 +19,26 @@ export interface Arc<This, Datum> {
     (this: This, d: Datum, ...args: any[]): string | undefined;
     centroid(d: Datum, ...args: any[]): [number, number];
     innerRadius(): (this: This, d: Datum, ...args: any[]) => number;
-    innerRadius(radius: number): Arc<This, Datum>;
-    innerRadius(radius: (this: This, d: Datum, ...args: any[]) => number): Arc<This, Datum>;
+    innerRadius(radius: number): this;
+    innerRadius(radius: (this: This, d: Datum, ...args: any[]) => number): this;
     outerRadius(): (this: This, d: Datum, ...args: any[]) => number;
-    outerRadius(radius: number): Arc<This, Datum>;
-    outerRadius(radius: (this: This, d: Datum, ...args: any[]) => number): Arc<This, Datum>;
+    outerRadius(radius: number): this;
+    outerRadius(radius: (this: This, d: Datum, ...args: any[]) => number): this;
     cornerRadius(): (this: This, d: Datum, ...args: any[]) => number;
-    cornerRadius(radius: number): Arc<This, Datum>;
-    cornerRadius(radius: (this: This, d: Datum, ...args: any[]) => number): Arc<This, Datum>;
+    cornerRadius(radius: number): this;
+    cornerRadius(radius: (this: This, d: Datum, ...args: any[]) => number): this;
     startAngle(): (this: This, d: Datum, ...args: any[]) => number;
-    startAngle(angle: number): Arc<This, Datum>;
-    startAngle(angle: (this: This, d: Datum, ...args: any[]) => number): Arc<This, Datum>;
+    startAngle(angle: number): this;
+    startAngle(angle: (this: This, d: Datum, ...args: any[]) => number): this;
     endAngle(): (this: This, d: Datum, ...args: any[]) => number;
-    endAngle(angle: number): Arc<This, Datum>;
-    endAngle(angle: (this: This, d: Datum, ...args: any[]) => number): Arc<This, Datum>;
+    endAngle(angle: number): this;
+    endAngle(angle: (this: This, d: Datum, ...args: any[]) => number): this;
     padAngle(): (this: This, d: Datum, ...args: any[]) => number;
-    padAngle(angle: number): Arc<This, Datum>;
-    padAngle(angle: (this: This, d: Datum, ...args: any[]) => number): Arc<This, Datum>;
+    padAngle(angle: number): this;
+    padAngle(angle: (this: This, d: Datum, ...args: any[]) => number): this;
     context(): CanvasRenderingContext2D | null;
-    context(context: CanvasRenderingContext2D): Arc<This, Datum>;
-    context(context: null): Arc<This, Datum>;
+    context(context: CanvasRenderingContext2D): this;
+    context(context: null): this;
 }
 
 export function arc(): Arc<any, DefaultArcObject>;
@@ -62,24 +62,24 @@ export interface PieArcDatum<T> {
 
 export interface Pie<This, Datum> {
     (this: This, data: Array<Datum>, ...args: any[]): Array<PieArcDatum<Datum>>;
-    value(): (d: Datum, i?: number, data?: Array<Datum>) => number;
-    value(value: number): Pie<This, Datum>;
-    value(value: (d: Datum, i?: number, data?: Array<Datum>) => number): Pie<This, Datum>;
+    value(): (d: Datum, i: number, data: Array<Datum>) => number;
+    value(value: number): this;
+    value(value: (d: Datum, i: number, data: Array<Datum>) => number): this;
     sort(): ((a: Datum, b: Datum) => number) | null;
-    sort(comparator: (a: Datum, b: Datum) => number): Pie<This, Datum>;
-    sort(comparator: null): Pie<This, Datum>;
+    sort(comparator: (a: Datum, b: Datum) => number): this;
+    sort(comparator: null): this;
     sortValues(): ((a: number, b: number) => number) | null;
-    sortValues(comparator: (a: number, b: number) => number): Pie<This, Datum>;
-    sortValues(comparator: null): Pie<This, Datum>;
+    sortValues(comparator: (a: number, b: number) => number): this;
+    sortValues(comparator: null): this;
     startAngle(): (this: This, data: Array<Datum>, ...args: any[]) => number;
-    startAngle(angle: number): Pie<This, Datum>;
-    startAngle(angle: (this: This, data: Array<Datum>, ...args: any[]) => number): Pie<This, Datum>;
+    startAngle(angle: number): this;
+    startAngle(angle: (this: This, data: Array<Datum>, ...args: any[]) => number): this;
     endAngle(): (this: This, data: Array<Datum>, ...args: any[]) => number;
-    endAngle(angle: number): Pie<This, Datum>;
-    endAngle(angle: (this: This, data: Array<Datum>, ...args: any[]) => number): Pie<This, Datum>;
+    endAngle(angle: number): this;
+    endAngle(angle: (this: This, data: Array<Datum>, ...args: any[]) => number): this;
     padAngle(): (this: This, data: Array<Datum>, ...args: any[]) => number;
-    padAngle(angle: number): Pie<This, Datum>;
-    padAngle(angle: (this: This, data: Array<Datum>, ...args: any[]) => number): Pie<This, Datum>;
+    padAngle(angle: number): this;
+    padAngle(angle: (this: This, data: Array<Datum>, ...args: any[]) => number): this;
 }
 
 export function pie(): Pie<any, number | { valueOf(): number }>;
@@ -93,20 +93,20 @@ export function pie<This, Datum>(): Pie<This, Datum>;
 
 export interface Line<Datum> {
     (data: Array<Datum>): string | undefined;
-    x(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    x(x: number): Line<Datum>;
-    x(x: (d: Datum, index?: number, data?: Array<Datum>) => number): Line<Datum>;
-    y(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    y(y: number): Line<Datum>;
-    y(y: (d: Datum, index?: number, data?: Array<Datum>) => number): Line<Datum>;
-    defined(): (d: Datum, index?: number, data?: Array<Datum>) => boolean;
-    defined(defined: boolean): Line<Datum>;
-    defined(defined: (d: Datum, index?: number, data?: Array<Datum>) => boolean): Line<Datum>;
+    x(): (d: Datum, index: number, data: Array<Datum>) => number;
+    x(x: number): this;
+    x(x: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    y(): (d: Datum, index: number, data: Array<Datum>) => number;
+    y(y: number): this;
+    y(y: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    defined(): (d: Datum, index: number, data: Array<Datum>) => boolean;
+    defined(defined: boolean): this;
+    defined(defined: (d: Datum, index: number, data: Array<Datum>) => boolean): this;
     curve(): CurveFactory | CurveFactoryLineOnly;
-    curve(curve: CurveFactory | CurveFactoryLineOnly): Line<Datum>;
+    curve(curve: CurveFactory | CurveFactoryLineOnly): this;
     context(): CanvasRenderingContext2D | null;
-    context(context: CanvasRenderingContext2D): Line<Datum>;
-    context(context: null): Line<Datum>;
+    context(context: CanvasRenderingContext2D): this;
+    context(context: null): this;
 }
 export function line(): Line<[number, number]>;
 export function line<Datum>(): Line<Datum>;
@@ -114,20 +114,20 @@ export function line<This, Datum>(): Line<Datum>;
 
 export interface RadialLine<Datum> {
     (data: Array<Datum>): string | undefined;
-    angle(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    angle(angle: number): RadialLine<Datum>;
-    angle(angle: (d: Datum, index?: number, data?: Array<Datum>) => number): RadialLine<Datum>;
-    radius(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    radius(radius: number): RadialLine<Datum>;
-    radius(radius: (d: Datum, index?: number, data?: Array<Datum>) => number): RadialLine<Datum>;
-    defined(): (d: Datum, index?: number, data?: Array<Datum>) => boolean;
-    defined(defined: boolean): RadialLine<Datum>;
-    defined(defined: (d: Datum, index?: number, data?: Array<Datum>) => boolean): RadialLine<Datum>;
+    angle(): (d: Datum, index: number, data: Array<Datum>) => number;
+    angle(angle: number): this;
+    angle(angle: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    radius(): (d: Datum, index: number, data: Array<Datum>) => number;
+    radius(radius: number): this;
+    radius(radius: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    defined(): (d: Datum, index: number, data: Array<Datum>) => boolean;
+    defined(defined: boolean): this;
+    defined(defined: (d: Datum, index: number, data: Array<Datum>) => boolean): this;
     curve(): CurveFactory | CurveFactoryLineOnly;
-    curve(curve: CurveFactory | CurveFactoryLineOnly): RadialLine<Datum>;
+    curve(curve: CurveFactory | CurveFactoryLineOnly): this;
     context(): CanvasRenderingContext2D | null;
-    context(context: CanvasRenderingContext2D): RadialLine<Datum>;
-    context(context: null): RadialLine<Datum>;
+    context(context: CanvasRenderingContext2D): this;
+    context(context: null): this;
 }
 
 export function radialLine(): RadialLine<[number, number]>;
@@ -140,32 +140,32 @@ export function radialLine<Datum>(): RadialLine<Datum>;
 
 export interface Area<Datum> {
     (data: Array<Datum>): string | undefined;
-    x(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    x(x: number): Area<Datum>;
-    x(x: (d: Datum, index?: number, data?: Array<Datum>) => number): Area<Datum>;
-    x0(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    x0(x0: number): Area<Datum>;
-    x0(x0: (d: Datum, index?: number, data?: Array<Datum>) => number): Area<Datum>;
-    x1(): ((d: Datum, index?: number, data?: Array<Datum>) => number) | null;
-    x1(x: number): Area<Datum>;
-    x1(x: (d: Datum, index?: number, data?: Array<Datum>) => number): Area<Datum>;
-    y(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    y(y: number): Area<Datum>;
-    y(y: (d: Datum, index?: number, data?: Array<Datum>) => number): Area<Datum>;
-    y0(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    y0(y: number): Area<Datum>;
-    y0(y: (d: Datum, index?: number, data?: Array<Datum>) => number): Area<Datum>;
-    y1(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    y1(y: number): Area<Datum>;
-    y1(y: (d: Datum, index?: number, data?: Array<Datum>) => number): Area<Datum>;
-    defined(): (d: Datum, index?: number, data?: Array<Datum>) => boolean;
-    defined(defined: boolean): Area<Datum>;
-    defined(defined: (d: Datum, index?: number, data?: Array<Datum>) => boolean): Area<Datum>;
+    x(): (d: Datum, index: number, data: Array<Datum>) => number;
+    x(x: number): this;
+    x(x: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    x0(): (d: Datum, index: number, data: Array<Datum>) => number;
+    x0(x0: number): this;
+    x0(x0: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    x1(): ((d: Datum, index: number, data: Array<Datum>) => number) | null;
+    x1(x: number): this;
+    x1(x: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    y(): (d: Datum, index: number, data: Array<Datum>) => number;
+    y(y: number): this;
+    y(y: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    y0(): (d: Datum, index: number, data: Array<Datum>) => number;
+    y0(y: number): this;
+    y0(y: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    y1(): (d: Datum, index: number, data: Array<Datum>) => number;
+    y1(y: number): this;
+    y1(y: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    defined(): (d: Datum, index: number, data: Array<Datum>) => boolean;
+    defined(defined: boolean): this;
+    defined(defined: (d: Datum, index: number, data: Array<Datum>) => boolean): this;
     curve(): CurveFactory;
-    curve(curve: CurveFactory): Area<Datum>;
+    curve(curve: CurveFactory): this;
     context(): CanvasRenderingContext2D | null;
-    context(context: CanvasRenderingContext2D): Area<Datum>;
-    context(context: null): Area<Datum>;
+    context(context: CanvasRenderingContext2D): this;
+    context(context: null): this;
     lineX0(): Line<Datum>;
     lineY0(): Line<Datum>;
     lineX1(): Line<Datum>;
@@ -178,32 +178,32 @@ export function area<Datum>(): Area<Datum>;
 
 export interface RadialArea<Datum> {
     (data: Array<Datum>): string | undefined;
-    angle(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    angle(angle: number): RadialArea<Datum>;
-    angle(angle: (d: Datum, index?: number, data?: Array<Datum>) => number): RadialArea<Datum>;
-    startAngle(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    startAngle(angle: number): RadialArea<Datum>;
-    startAngle(angle: (d: Datum, index?: number, data?: Array<Datum>) => number): RadialArea<Datum>;
-    endAngle(): ((d: Datum, index?: number, data?: Array<Datum>) => number) | null;
-    endAngle(angle: number): RadialArea<Datum>;
-    endAngle(angle: (d: Datum, index?: number, data?: Array<Datum>) => number): RadialArea<Datum>;
-    radius(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    radius(radius: number): RadialArea<Datum>;
-    radius(radius: (d: Datum, index?: number, data?: Array<Datum>) => number): RadialArea<Datum>;
-    innerRadius(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    innerRadius(radius: number): RadialArea<Datum>;
-    innerRadius(radius: (d: Datum, index?: number, data?: Array<Datum>) => number): RadialArea<Datum>;
-    outerRadius(): (d: Datum, index?: number, data?: Array<Datum>) => number;
-    outerRadius(radius: number): RadialArea<Datum>;
-    outerRadius(radius: (d: Datum, index?: number, data?: Array<Datum>) => number): RadialArea<Datum>;
-    defined(): (d: Datum, index?: number, data?: Array<Datum>) => boolean;
-    defined(defined: boolean): RadialArea<Datum>;
-    defined(defined: (d: Datum, index?: number, data?: Array<Datum>) => boolean): RadialArea<Datum>;
+    angle(): (d: Datum, index: number, data: Array<Datum>) => number;
+    angle(angle: number): this;
+    angle(angle: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    startAngle(): (d: Datum, index: number, data: Array<Datum>) => number;
+    startAngle(angle: number): this;
+    startAngle(angle: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    endAngle(): ((d: Datum, index: number, data: Array<Datum>) => number) | null;
+    endAngle(angle: number): this;
+    endAngle(angle: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    radius(): (d: Datum, index: number, data: Array<Datum>) => number;
+    radius(radius: number): this;
+    radius(radius: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    innerRadius(): (d: Datum, index: number, data: Array<Datum>) => number;
+    innerRadius(radius: number): this;
+    innerRadius(radius: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    outerRadius(): (d: Datum, index: number, data: Array<Datum>) => number;
+    outerRadius(radius: number): this;
+    outerRadius(radius: (d: Datum, index: number, data: Array<Datum>) => number): this;
+    defined(): (d: Datum, index: number, data: Array<Datum>) => boolean;
+    defined(defined: boolean): this;
+    defined(defined: (d: Datum, index: number, data: Array<Datum>) => boolean): this;
     curve(): CurveFactory;
-    curve(curve: CurveFactory): RadialArea<Datum>;
+    curve(curve: CurveFactory): this;
     context(): CanvasRenderingContext2D | null;
-    context(context: CanvasRenderingContext2D): RadialArea<Datum>;
-    context(context: null): RadialArea<Datum>;
+    context(context: CanvasRenderingContext2D): this;
+    context(context: null): this;
     lineStartAngle(): RadialLine<Datum>;
     lineInnerRadius(): RadialLine<Datum>;
     lineEndAngle(): RadialLine<Datum>;
@@ -243,13 +243,13 @@ export var curveBasisOpen: CurveFactory;
 export var curveBasisClosed: CurveFactory;
 
 export interface CurveBundleFactory extends CurveFactoryLineOnly {
-    beta(beta: number): CurveBundleFactory;
+    beta(beta: number): this;
 }
 
 export var curveBundle: CurveBundleFactory;
 
 export interface CurveCardinalFactory extends CurveFactory {
-    tension(tension: number): CurveCardinalFactory;
+    tension(tension: number): this;
 }
 
 export var curveCardinal: CurveCardinalFactory;
@@ -257,7 +257,7 @@ export var curveCardinalOpen: CurveCardinalFactory;
 export var curveCardinalClosed: CurveCardinalFactory;
 
 export interface CurveCatmullRomFactory extends CurveFactory {
-    alpha(alpha: number): CurveCatmullRomFactory;
+    alpha(alpha: number): this;
 }
 
 export var curveCatmullRom: CurveCatmullRomFactory;
@@ -291,16 +291,16 @@ export interface SymbolType {
 
 
 export interface Symbol<This, Datum> {
-    (this: This, d?: Datum, ...args: any[]): undefined | string;
-    size(): (this: This, d?: Datum, ...args: any[]) => number;
-    size(size: number): Symbol<This, Datum>;
-    size(size: (this: This, d?: Datum, ...args: any[]) => number): Symbol<This, Datum>;
-    type(): (this: This, d?: Datum, ...args: any[]) => SymbolType;
-    type(type: SymbolType): Symbol<This, Datum>;
-    type(type: (this: This, d?: Datum, ...args: any[]) => SymbolType): Symbol<This, Datum>;
+    (this: This, d: Datum, ...args: any[]): undefined | string;
+    size(): (this: This, d: Datum, ...args: any[]) => number;
+    size(size: number): this;
+    size(size: (this: This, d: Datum, ...args: any[]) => number): this;
+    type(): (this: This, d: Datum, ...args: any[]) => SymbolType;
+    type(type: SymbolType): this;
+    type(type: (this: This, d: Datum, ...args: any[]) => SymbolType): this;
     context(): CanvasRenderingContext2D | null;
-    context(context: CanvasRenderingContext2D): Symbol<This, Datum>;
-    context(context: null): Symbol<This, Datum>;
+    context(context: CanvasRenderingContext2D): this;
+    context(context: null): this;
 
 }
 
@@ -342,21 +342,21 @@ export interface Stack<This, Datum, Key> {
     (data: Array<Datum>, ...args: any[]): Array<Series<Datum, Key>>;
 
     keys(): (this: This, data: Array<Datum>, ...args: any[]) => Array<Key>;
-    keys(keys: Array<Key>): Stack<This, Datum, Key>;
-    keys(keys: (this: This, data: Array<Datum>, ...args: any[]) => Array<Key>): Stack<This, Datum, Key>;
+    keys(keys: Array<Key>): this;
+    keys(keys: (this: This, data: Array<Datum>, ...args: any[]) => Array<Key>): this;
 
-    value(): (d: Datum, key: Key, j?: number, data?: Array<Datum>) => number;
-    value(value: number): Stack<This, Datum, Key>;
-    value(value: (d: Datum, key: Key, j?: number, data?: Array<Datum>) => number): Stack<This, Datum, Key>;
+    value(): (d: Datum, key: Key, j: number, data: Array<Datum>) => number;
+    value(value: number): this;
+    value(value: (d: Datum, key: Key, j: number, data: Array<Datum>) => number): this;
 
     order(): (series: Series<Datum, Key>) => Array<number>;
-    order(order: null): Stack<This, Datum, Key>;
-    order(order: Array<number>): Stack<This, Datum, Key>;
-    order(order: (series: Series<Datum, Key>) => Array<number>): Stack<This, Datum, Key>;
+    order(order: null): this;
+    order(order: Array<number>): this;
+    order(order: (series: Series<Datum, Key>) => Array<number>): this;
 
     offset(): (series: Series<Datum, Key>, order: Array<number>) => void;
-    offset(offset: null): Stack<This, Datum, Key>;
-    offset(offset: (series: Series<Datum, Key>, order: Array<number>) => void): Stack<This, Datum, Key>;
+    offset(offset: null): this;
+    offset(offset: (series: Series<Datum, Key>, order: Array<number>) => void): this;
 
 }
 

--- a/src/d3-time/index.d.ts
+++ b/src/d3-time/index.d.ts
@@ -14,7 +14,7 @@ export interface TimeInterval {
     ceil(date: Date): Date;
     offset(date: Date, step?: number): Date;
     range(start: Date, stop: Date, step?: number): Date[];
-    filter(test: (date: Date) => boolean): TimeInterval;
+    filter(test: (date: Date) => boolean): this;
 }
 
 export interface CountableTimeInterval extends TimeInterval {

--- a/src/d3-transition/index.d.ts
+++ b/src/d3-transition/index.d.ts
@@ -40,42 +40,42 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
 
     // Modifying -------------------------------
 
-    attr(name: string, value: null): Transition<GElement, Datum, PElement, PDatum>;
-    attr(name: string, value: string | number | boolean): Transition<GElement, Datum, PElement, PDatum>;
-    attr(name: string, value: ValueFn<GElement, Datum, string | number | boolean>): Transition<GElement, Datum, PElement, PDatum>;
-    attrTween(name: string, tweenFn: ValueFn<GElement, Datum, (t: number) => (string | number | boolean)>): Transition<GElement, Datum, PElement, PDatum>;
+    attr(name: string, value: null): this;
+    attr(name: string, value: string | number | boolean): this;
+    attr(name: string, value: ValueFn<GElement, Datum, string | number | boolean>): this;
+    attrTween(name: string, tweenFn: ValueFn<GElement, Datum, (t: number) => (string | number | boolean)>): this;
 
-    style(name: string, value: null): Transition<GElement, Datum, PElement, PDatum>;
-    style(name: string, value: string | number | boolean, priority?: null | 'important'): Transition<GElement, Datum, PElement, PDatum>;
-    style(name: string, value: ValueFn<GElement, Datum, string | number | boolean>, priority?: null | 'important'): Transition<GElement, Datum, PElement, PDatum>;
-    styleTween(name: string, tweenFn: ValueFn<GElement, Datum, (t: number) => (string | number | boolean)>, priority?: null | 'important'): Transition<GElement, Datum, PElement, PDatum>;
+    style(name: string, value: null): this;
+    style(name: string, value: string | number | boolean, priority?: null | 'important'): this;
+    style(name: string, value: ValueFn<GElement, Datum, string | number | boolean>, priority?: null | 'important'): this;
+    styleTween(name: string, tweenFn: ValueFn<GElement, Datum, (t: number) => (string | number | boolean)>, priority?: null | 'important'): this;
 
-    text(value: null): Transition<GElement, Datum, PElement, PDatum>;
-    text(value: string | number | boolean): Transition<GElement, Datum, PElement, PDatum>;
-    text(value: ValueFn<GElement, Datum, string | number | boolean>): Transition<GElement, Datum, PElement, PDatum>;
+    text(value: null): this;
+    text(value: string | number | boolean): this;
+    text(value: ValueFn<GElement, Datum, string | number | boolean>): this;
 
-    tween(name: string): (this: GElement, datum?: Datum, i?: number, group?: GElement[] | ArrayLike<GElement>) => ((t: number) => void);
-    tween(name: string, tweenFn: null): Transition<GElement, Datum, PElement, PDatum>;
-    tween(name: string, tweenFn: ValueFn<GElement, Datum, (t: number) => void>): Transition<GElement, Datum, PElement, PDatum>;
+    tween(name: string): ValueFn<GElement, Datum, (t: number) => void>;
+    tween(name: string, tweenFn: null): this;
+    tween(name: string, tweenFn: ValueFn<GElement, Datum, (t: number) => void>): this;
 
-    remove(): Transition<GElement, Datum, PElement, PDatum>;
+    remove(): this;
 
     merge(other: Transition<GElement, Datum, PElement, PDatum>): Transition<GElement, Datum, PElement, PDatum>;
 
-    filter(filter: string): Transition<GElement, Datum, PElement, PDatum>;
-    filter(filter: ValueFn<GElement, Datum, boolean>): Transition<GElement, Datum, PElement, PDatum>;
+    filter(filter: string): this;
+    filter(filter: ValueFn<GElement, Datum, boolean>): this;
 
     // Event Handling -------------------
 
     on(type: string): ValueFn<GElement, Datum, void>;
-    on(type: string, listener: null): Transition<GElement, Datum, PElement, PDatum>;
-    on(type: string, listener: ValueFn<GElement, Datum, void>): Transition<GElement, Datum, PElement, PDatum>;
+    on(type: string, listener: null): this;
+    on(type: string, listener: ValueFn<GElement, Datum, void>): this;
 
     // Control Flow ----------------------
 
-    each(valueFn: ValueFn<GElement, Datum, void>): Transition<GElement, Datum, PElement, PDatum>;
+    each(valueFn: ValueFn<GElement, Datum, void>): this;
 
-    call(func: (transition: Transition<GElement, Datum, PElement, PDatum>, ...args: any[]) => any, ...args: any[]): Transition<GElement, Datum, PElement, PDatum>;
+    call(func: (transition: Transition<GElement, Datum, PElement, PDatum>, ...args: any[]) => any, ...args: any[]): this;
 
     empty(): boolean;
 
@@ -87,13 +87,13 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
     // Transition Configuration ----------------------
 
     delay(): number;
-    delay(milliseconds: number): Transition<GElement, Datum, PElement, PDatum>;
+    delay(milliseconds: number): this;
 
     duration(): number;
-    duration(milliseconds: number): Transition<GElement, Datum, PElement, PDatum>;
+    duration(milliseconds: number): this;
 
     ease(): (normalizedTime: number) => number;
-    ease(easingFn: (normalizedTime: number) => number): Transition<GElement, Datum, PElement, PDatum>;
+    ease(easingFn: (normalizedTime: number) => number): this;
 }
 
 

--- a/src/d3-transition/index.d.ts
+++ b/src/d3-transition/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ArrayLike, BaseType, Selection } from '../d3-selection';
+import { ArrayLike, BaseType, Selection, ValueFn } from '../d3-selection';
 
 /**
  * Extend interface 'Selection' by declaration merging with 'd3-selection'
@@ -26,14 +26,14 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
     // Sub-selection -------------------------
 
     select<DescElement extends BaseType>(selector: string): Transition<DescElement, Datum, PElement, PDatum>;
-    select<DescElement extends BaseType>(selector: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => DescElement): Transition<DescElement, Datum, PElement, PDatum>;
+    select<DescElement extends BaseType>(selector: ValueFn<GElement, Datum, DescElement>): Transition<DescElement, Datum, PElement, PDatum>;
 
     // NB: while the empty selections (null or undefined selector) are defined on the underlying object, they should not be exposed in the type definition API
     // as they are meaningless on transitions.)
     // selectAll(): Transition<undefined, undefined, GElement, Datum>; // _groups are set to empty array, first generic type is set to undefined by convention
     // selectAll(selector: null): Transition<undefined, undefined, GElement, Datum>; // _groups are set to empty array, first generic type is set to undefined by convention
     selectAll<DescElement extends BaseType, OldDatum>(selector: string): Transition<DescElement, OldDatum, GElement, Datum>;
-    selectAll<DescElement extends BaseType, OldDatum>(selector: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => (Array<DescElement> | ArrayLike<DescElement>)): Transition<DescElement, OldDatum, GElement, Datum>;
+    selectAll<DescElement extends BaseType, OldDatum>(selector: ValueFn<GElement, Datum, Array<DescElement> | ArrayLike<DescElement>>): Transition<DescElement, OldDatum, GElement, Datum>;
 
     selection(): Selection<GElement, Datum, PElement, PDatum>;
     transition(): Transition<GElement, Datum, PElement, PDatum>;
@@ -42,38 +42,38 @@ export interface Transition<GElement extends BaseType, Datum, PElement extends B
 
     attr(name: string, value: null): Transition<GElement, Datum, PElement, PDatum>;
     attr(name: string, value: string | number | boolean): Transition<GElement, Datum, PElement, PDatum>;
-    attr(name: string, value: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => (string | number | boolean)): Transition<GElement, Datum, PElement, PDatum>;
-    attrTween(name: string, tweenFn: (this: GElement, datum?: Datum, i?: number, group?: GElement[] | ArrayLike<GElement>) => ((t: number) => (string | number | boolean))): Transition<GElement, Datum, PElement, PDatum>;
+    attr(name: string, value: ValueFn<GElement, Datum, string | number | boolean>): Transition<GElement, Datum, PElement, PDatum>;
+    attrTween(name: string, tweenFn: ValueFn<GElement, Datum, (t: number) => (string | number | boolean)>): Transition<GElement, Datum, PElement, PDatum>;
 
     style(name: string, value: null): Transition<GElement, Datum, PElement, PDatum>;
     style(name: string, value: string | number | boolean, priority?: null | 'important'): Transition<GElement, Datum, PElement, PDatum>;
-    style(name: string, value: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => (string | number | boolean), priority?: null | 'important'): Transition<GElement, Datum, PElement, PDatum>;
-    styleTween(name: string, tweenFn: (this: GElement, datum?: Datum, i?: number, group?: GElement[] | ArrayLike<GElement>) => ((t: number) => (string | number | boolean)), priority?: null | 'important'): Transition<GElement, Datum, PElement, PDatum>;
+    style(name: string, value: ValueFn<GElement, Datum, string | number | boolean>, priority?: null | 'important'): Transition<GElement, Datum, PElement, PDatum>;
+    styleTween(name: string, tweenFn: ValueFn<GElement, Datum, (t: number) => (string | number | boolean)>, priority?: null | 'important'): Transition<GElement, Datum, PElement, PDatum>;
 
     text(value: null): Transition<GElement, Datum, PElement, PDatum>;
     text(value: string | number | boolean): Transition<GElement, Datum, PElement, PDatum>;
-    text(value: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => (string | number | boolean)): Transition<GElement, Datum, PElement, PDatum>;
+    text(value: ValueFn<GElement, Datum, string | number | boolean>): Transition<GElement, Datum, PElement, PDatum>;
 
     tween(name: string): (this: GElement, datum?: Datum, i?: number, group?: GElement[] | ArrayLike<GElement>) => ((t: number) => void);
     tween(name: string, tweenFn: null): Transition<GElement, Datum, PElement, PDatum>;
-    tween(name: string, tweenFn: (this: GElement, datum?: Datum, i?: number, group?: GElement[] | ArrayLike<GElement>) => ((t: number) => void)): Transition<GElement, Datum, PElement, PDatum>;
+    tween(name: string, tweenFn: ValueFn<GElement, Datum, (t: number) => void>): Transition<GElement, Datum, PElement, PDatum>;
 
     remove(): Transition<GElement, Datum, PElement, PDatum>;
 
     merge(other: Transition<GElement, Datum, PElement, PDatum>): Transition<GElement, Datum, PElement, PDatum>;
 
     filter(filter: string): Transition<GElement, Datum, PElement, PDatum>;
-    filter(filter: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => boolean): Transition<GElement, Datum, PElement, PDatum>;
+    filter(filter: ValueFn<GElement, Datum, boolean>): Transition<GElement, Datum, PElement, PDatum>;
 
     // Event Handling -------------------
 
-    on(type: string): (this: GElement, datum: Datum, index: number, group: Array<GElement> | ArrayLike<GElement>) => any;
+    on(type: string): ValueFn<GElement, Datum, void>;
     on(type: string, listener: null): Transition<GElement, Datum, PElement, PDatum>;
-    on(type: string, listener: (this: GElement, datum: Datum, index: number, group: Array<GElement> | ArrayLike<GElement>) => any): Transition<GElement, Datum, PElement, PDatum>;
+    on(type: string, listener: ValueFn<GElement, Datum, void>): Transition<GElement, Datum, PElement, PDatum>;
 
     // Control Flow ----------------------
 
-    each(valueFn: (this: GElement, datum?: Datum, index?: number, group?: Array<GElement> | ArrayLike<GElement>) => void): Transition<GElement, Datum, PElement, PDatum>;
+    each(valueFn: ValueFn<GElement, Datum, void>): Transition<GElement, Datum, PElement, PDatum>;
 
     call(func: (transition: Transition<GElement, Datum, PElement, PDatum>, ...args: any[]) => any, ...args: any[]): Transition<GElement, Datum, PElement, PDatum>;
 

--- a/src/d3-voronoi/index.d.ts
+++ b/src/d3-voronoi/index.d.ts
@@ -53,13 +53,13 @@ export interface VoronoiLink<T> {
 export interface VoronoiLayout<T> {
     (data: Array<T>): VoronoiDiagram<T>;
     x(): (d: T) => number;
-    x(x: (d: T) => number): VoronoiLayout<T>;
+    x(x: (d: T) => number): this;
     y(): (d: T) => number;
-    y(y: (d: T) => number): VoronoiLayout<T>;
+    y(y: (d: T) => number): this;
     extent(): [[number, number], [number, number]] | null;
-    extent(extent: [[number, number], [number, number]]): VoronoiLayout<T>;
+    extent(extent: [[number, number], [number, number]]): this;
     size(): [number, number] | null;
-    size(size: [number, number]): VoronoiLayout<T>;
+    size(size: [number, number]): this;
     polygons(data: Array<T>): Array<VoronoiPolygon<T>>;
     triangles(data: Array<T>): Array<VoronoiTriangle<T>>;
     links(data: Array<T>): Array<VoronoiLink<T>>;

--- a/src/d3-zoom/index.d.ts
+++ b/src/d3-zoom/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ArrayLike, Selection, TransitionLike } from '../d3-selection';
+import { ArrayLike, Selection, TransitionLike, ValueFn } from '../d3-selection';
 
 
 // --------------------------------------------------------------------------
@@ -24,9 +24,9 @@ type ZoomedElementBaseType = Element;
  */
 export interface ZoomScale {
     domain(): Array<number>;
-    domain(domain: Array<number>): ZoomScale;
+    domain(domain: Array<number>): this;
     range(): Array<number>;
-    range(range: Array<number>): ZoomScale;
+    range(range: Array<number>): this;
     copy(): ZoomScale;
     invert(value: number): number;
 }
@@ -39,60 +39,48 @@ export interface ZoomScale {
 export interface ZoomBehavior<ZoomRefElement extends ZoomedElementBaseType, Datum> extends Function {
     (selection: Selection<ZoomRefElement, Datum, any, any>, ...args: any[]): void;
     transform(selection: Selection<ZoomRefElement, Datum, any, any>, transform: ZoomTransform): void;
-    transform(selection: Selection<ZoomRefElement, Datum, any, any>, transform: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => ZoomTransform): void;
+    transform(selection: Selection<ZoomRefElement, Datum, any, any>, transform: ValueFn<ZoomRefElement, Datum, ZoomTransform>): void;
     transform(transition: TransitionLike<ZoomRefElement, Datum>, transform: ZoomTransform): void;
-    transform(transition: TransitionLike<ZoomRefElement, Datum>, transform: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => ZoomTransform): void;
+    transform(transition: TransitionLike<ZoomRefElement, Datum>, transform: ValueFn<ZoomRefElement, Datum, ZoomTransform>): void;
 
     translateBy(selection: Selection<ZoomRefElement, Datum, any, any>, x: number, y: number): void;
-    translateBy(selection: Selection<ZoomRefElement, Datum, any, any>,
-        x: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number,
-        y: number): void;
-    translateBy(selection: Selection<ZoomRefElement, Datum, any, any>,
-        x: number,
-        y: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number): void;
-    translateBy(selection: Selection<ZoomRefElement, Datum, any, any>,
-        x: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number,
-        y: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement>) => number): void;
+    translateBy(selection: Selection<ZoomRefElement, Datum, any, any>, x: ValueFn<ZoomRefElement, Datum, number>, y: number): void;
+    translateBy(selection: Selection<ZoomRefElement, Datum, any, any>, x: number, y: ValueFn<ZoomRefElement, Datum, number>): void;
+    translateBy(selection: Selection<ZoomRefElement, Datum, any, any>, x: ValueFn<ZoomRefElement, Datum, number>, y: ValueFn<ZoomRefElement, Datum, number>): void;
     translateBy(transition: TransitionLike<ZoomRefElement, Datum>, x: number, y: number): void;
-    translateBy(transition: TransitionLike<ZoomRefElement, Datum>,
-        x: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number,
-        y: number): void;
-    translateBy(transition: TransitionLike<ZoomRefElement, Datum>,
-        x: number,
-        y: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number): void;
-    translateBy(transition: TransitionLike<ZoomRefElement, Datum>,
-        x: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number,
-        y: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number): void;
+    translateBy(transition: TransitionLike<ZoomRefElement, Datum>, x: ValueFn<ZoomRefElement, Datum, number>, y: number): void;
+    translateBy(transition: TransitionLike<ZoomRefElement, Datum>, x: number, y: ValueFn<ZoomRefElement, Datum, number>): void;
+    translateBy(transition: TransitionLike<ZoomRefElement, Datum>, x: ValueFn<ZoomRefElement, Datum, number>, y: ValueFn<ZoomRefElement, Datum, number>): void;
 
     scaleBy(selection: Selection<ZoomRefElement, Datum, any, any>, k: number): void;
-    scaleBy(selection: Selection<ZoomRefElement, Datum, any, any>, k: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number): void;
+    scaleBy(selection: Selection<ZoomRefElement, Datum, any, any>, k: ValueFn<ZoomRefElement, Datum, number>): void;
     scaleBy(transition: TransitionLike<ZoomRefElement, Datum>, k: number): void;
-    scaleBy(transition: TransitionLike<ZoomRefElement, Datum>, k: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number): void;
+    scaleBy(transition: TransitionLike<ZoomRefElement, Datum>, k: ValueFn<ZoomRefElement, Datum, number>): void;
 
     scaleTo(selection: Selection<ZoomRefElement, Datum, any, any>, k: number): void;
-    scaleTo(selection: Selection<ZoomRefElement, Datum, any, any>, k: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number): void;
+    scaleTo(selection: Selection<ZoomRefElement, Datum, any, any>, k: ValueFn<ZoomRefElement, Datum, number>): void;
     scaleTo(transition: TransitionLike<ZoomRefElement, Datum>, k: number): void;
-    scaleTo(transition: TransitionLike<ZoomRefElement, Datum>, k: (this: ZoomRefElement, d?: Datum, i?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => number): void;
+    scaleTo(transition: TransitionLike<ZoomRefElement, Datum>, k: ValueFn<ZoomRefElement, Datum, number>): void;
 
-    filter(): (this: ZoomRefElement, datum: Datum, index: number, group: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => boolean;
-    filter(filterFn: (this: ZoomRefElement, d?: Datum, index?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => boolean): ZoomBehavior<ZoomRefElement, Datum>;
+    filter(): ValueFn<ZoomRefElement, Datum, boolean>;
+    filter(filterFn: ValueFn<ZoomRefElement, Datum, boolean>): this;
 
-    extent(): (this: ZoomRefElement, d: Datum, index: number, group: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => [[number, number], [number, number]];
-    extent(extent: [[number, number], [number, number]]): ZoomBehavior<ZoomRefElement, Datum>;
-    extent(extent: (this: ZoomRefElement, d?: Datum, index?: number, group?: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => [[number, number], [number, number]]): ZoomBehavior<ZoomRefElement, Datum>;
+    extent(): ValueFn<ZoomRefElement, Datum, [[number, number], [number, number]]>;
+    extent(extent: [[number, number], [number, number]]): this;
+    extent(extent: ValueFn<ZoomRefElement, Datum, [[number, number], [number, number]]>): this;
 
     scaleExtent(): [number, number];
-    scaleExtent(extent: [number, number]): ZoomBehavior<ZoomRefElement, Datum>;
+    scaleExtent(extent: [number, number]): this;
 
     translateExtent(): [[number, number], [number, number]];
-    translateExtent(extent: [[number, number], [number, number]]): ZoomBehavior<ZoomRefElement, Datum>;
+    translateExtent(extent: [[number, number], [number, number]]): this;
 
     duration(): number;
-    duration(duration: number): ZoomBehavior<ZoomRefElement, Datum>;
+    duration(duration: number): this;
 
-    on(typenames: string): (this: ZoomRefElement, datum: Datum, index: number, group: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => void;
-    on(typenames: string, callback: null): ZoomBehavior<ZoomRefElement, Datum>;
-    on(typenames: string, callback: (this: ZoomRefElement, datum: Datum, index: number, group: Array<ZoomRefElement> | ArrayLike<ZoomRefElement>) => void): ZoomBehavior<ZoomRefElement, Datum>;
+    on(typenames: string): ValueFn<ZoomRefElement, Datum, void>;
+    on(typenames: string, callback: null): this;
+    on(typenames: string, callback: ValueFn<ZoomRefElement, Datum, void>): this;
 }
 
 

--- a/tests/d3-force/d3-force-test.ts
+++ b/tests/d3-force/d3-force-test.ts
@@ -511,11 +511,11 @@ nodeSimulation = nodeSimulation.on('tick', null);
 
 // restart() --------------------------------------------------------------------------
 
-nodeLinkSimulation.restart();
+nodeLinkSimulation = nodeLinkSimulation.restart();
 
 // stop() -----------------------------------------------------------------------------
 
-nodeLinkSimulation.stop();
+nodeLinkSimulation = nodeLinkSimulation.stop();
 
 // tick() -----------------------------------------------------------------------------
 

--- a/tests/d3-interpolate/d3-interpolate-test.ts
+++ b/tests/d3-interpolate/d3-interpolate-test.ts
@@ -8,6 +8,7 @@
 
 import * as d3Color from '../../src/d3-color';
 import * as d3Interpolate from '../../src/d3-interpolate';
+import * as d3Hsv from '../../src/d3-hsv';
 
 // Preparatory steps -------------------------------------------------------------------
 
@@ -56,6 +57,7 @@ let num: number,
     arrStr: string[],
     objKeyVal: { [key: string]: any },
     objRGBColor: d3Color.RGBColor,
+    objHSVColor: d3Hsv.HSVColor,
     zoom: [number, number, number];
 
 // test interpolate(a, b) signature ----------------------------------------------------
@@ -65,6 +67,7 @@ iNum = d3Interpolate.interpolate('1', 5);
 
 // color interpolator returning a color string
 iString = d3Interpolate.interpolate('seagreen', d3Color.rgb(100, 100, 100));
+iString = d3Interpolate.interpolate('seagreen', d3Hsv.hsv(60, 1, 0.2, 0.4));
 iString = d3Interpolate.interpolate('seagreen', 'steelblue'); // as used with valid color name string
 
 // date interpolator
@@ -168,6 +171,7 @@ arrStr = d3Interpolate.quantize<string>(d3Interpolate.interpolateString('-1', '2
 // without gamma correction
 iString = d3Interpolate.interpolateRgb('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateRgb(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
+iString = d3Interpolate.interpolateRgb(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 str = iString(0.5);
 
 // with gamma correction
@@ -176,34 +180,41 @@ iString = d3Interpolate.interpolateRgb.gamma(2.2)('purple', 'orange');
 // test interpolateRgbBasis(color) and  interpolateRgbBasisClosed(color) signatures -------------------------
 
 iString = d3Interpolate.interpolateRgbBasis(['seagreen', d3Color.rgb('steelblue'), 'rgb(100, 100, 100)']);
-iString = d3Interpolate.interpolateRgbBasisClosed(['seagreen', d3Color.rgb('steelblue'), 'rgb(100, 100, 100)']);
+iString = d3Interpolate.interpolateRgbBasis(['seagreen', d3Hsv.hsv('steelblue'), 'rgb(100, 100, 100)']);
+iString = d3Interpolate.interpolateRgbBasisClosed(['seagreen', d3Hsv.hsv('steelblue'), 'rgb(100, 100, 100)']);
 
 // test interpolateHsl(a, b) and interpolateHslLong(a, b)----------------------------------------------------------------
 
 iString = d3Interpolate.interpolateHsl('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateHsl(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
+iString = d3Interpolate.interpolateHsl(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 
 iString = d3Interpolate.interpolateHslLong('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateHslLong(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
+iString = d3Interpolate.interpolateHslLong(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 
 // test interpolateLab(a, b) --------------------------------------------------------------------------------------------
 
 iString = d3Interpolate.interpolateLab('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateLab(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
+iString = d3Interpolate.interpolateLab(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 
 // test interpolateHcl(a, b) and interpolateHclLong(a, b) ----------------------------------------------------------------
 
 iString = d3Interpolate.interpolateHcl('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateHcl(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
+iString = d3Interpolate.interpolateHcl(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 
 iString = d3Interpolate.interpolateHclLong('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateHclLong(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
+iString = d3Interpolate.interpolateHclLong(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 
 // test interpolateCubehelix(a, b) and interpolateCubehelixLong(a, b) ---------------------------------------------------
 
 // without gamma correction
 iString = d3Interpolate.interpolateCubehelix('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateCubehelix(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
+iString = d3Interpolate.interpolateCubehelix(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 str = iString(0.5);
 
 // with gamma correction
@@ -212,6 +223,7 @@ iString = d3Interpolate.interpolateCubehelix.gamma(2.2)('purple', 'orange');
 // without gamma correction
 iString = d3Interpolate.interpolateCubehelixLong('seagreen', 'steelblue');
 iString = d3Interpolate.interpolateCubehelixLong(d3Color.rgb('seagreen'), d3Color.hcl('steelblue'));
+iString = d3Interpolate.interpolateCubehelixLong(d3Color.rgb('seagreen'), d3Hsv.hsv('steelblue'));
 str = iString(0.5);
 
 // with gamma correction


### PR DESCRIPTION
- Fixes #66. (Chore: `this` return type)
- Fixes #89 (Bug: d3-zoom tick() return type)
- Fixes #88 (Bug: d3-brush move() return type)
- Fixes #87. (Chore: callback function signatures, reuse of `ValueFn` type alias)
- Fixes #86 (`ScaleSequential` generalization to allow coercible numeric value as argument)
- Fixes #85 (generalize d3-color and d3-interpolate to accommodate d3-hsv color objects and similar extensions)
