### PR TITLE
Chore:

### DIFF
--- a/src/d3-axis/index.d.ts
+++ b/src/d3-axis/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-axis module 1.0.0
 // Project: https://github.com/d3/d3-axis/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { Selection, TransitionLike } from '../d3-selection';

--- a/src/d3-brush/index.d.ts
+++ b/src/d3-brush/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-brush module 1.0.1
 // Project: https://github.com/d3/d3-brush/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { ArrayLike, Selection, TransitionLike, ValueFn } from '../d3-selection';

--- a/src/d3-chord/index.d.ts
+++ b/src/d3-chord/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-chord module 1.0.0
 // Project: https://github.com/d3/d3-chord/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // ---------------------------------------------------------------------

--- a/src/d3-collection/index.d.ts
+++ b/src/d3-collection/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-collection module 1.0.0
 // Project: https://github.com/d3/d3-collection/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/src/d3-color/index.d.ts
+++ b/src/d3-color/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-color module 1.0.0
 // Project: https://github.com/d3/d3-color/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // ---------------------------------------------------------------------------

--- a/src/d3-dispatch/index.d.ts
+++ b/src/d3-dispatch/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-dispatch module 1.0.0
 // Project: https://github.com/d3/d3-dispatch/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Dispatch<T extends EventTarget> {

--- a/src/d3-drag/index.d.ts
+++ b/src/d3-drag/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-drag module 1.0.0
 // Project: https://github.com/d3/d3-drag/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { ArrayLike, Selection, ValueFn } from '../d3-selection';

--- a/src/d3-dsv/index.d.ts
+++ b/src/d3-dsv/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-dsv module 1.0.0
 // Project: https://github.com/d3/d3-dsv/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // ------------------------------------------------------------------------------------------

--- a/src/d3-ease/index.d.ts
+++ b/src/d3-ease/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-ease module 1.0.0
 // Project: https://github.com/d3/d3-ease/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // --------------------------------------------------------------------------

--- a/src/d3-force/index.d.ts
+++ b/src/d3-force/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-force module 1.0.0
 // Project: https://github.com/d3/d3-force/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 

--- a/src/d3-format/index.d.ts
+++ b/src/d3-format/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-format module 1.0.0
 // Project: https://github.com/d3/d3-format/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/src/d3-hierarchy/index.d.ts
+++ b/src/d3-hierarchy/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-hierarchy module 1.0.0
 // Project: https://github.com/d3/d3-hierarchy/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // -----------------------------------------------------------------------

--- a/src/d3-interpolate/index.d.ts
+++ b/src/d3-interpolate/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-interpolate module 1.1.0
 // Project: https://github.com/d3/d3-interpolate/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { ColorCommonInstance, RGBColor } from '../d3-color';

--- a/src/d3-path/index.d.ts
+++ b/src/d3-path/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-path module 1.0.0
 // Project: https://github.com/d3/d3-path/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export interface Path {

--- a/src/d3-polygon/index.d.ts
+++ b/src/d3-polygon/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-polygon module 1.0.0
 // Project: https://github.com/d3/d3-polygon/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/src/d3-quadtree/index.d.ts
+++ b/src/d3-quadtree/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-quadtree module 1.0.0
 // Project: https://github.com/d3/d3-quadtree/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/src/d3-queue/index.d.ts
+++ b/src/d3-queue/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-queue module 3.0.1
 // Project: https://github.com/d3/d3-queue/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/src/d3-random/index.d.ts
+++ b/src/d3-random/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-random module 1.0.0
 // Project: https://github.com/d3/d3-random/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/src/d3-request/index.d.ts
+++ b/src/d3-request/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-request module 1.0.1
 // Project: https://github.com/d3/d3-request/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Hugues Stefanski <https://github.com/Ledragon>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Hugues Stefanski <https://github.com/Ledragon>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { DSVParsedArray, DSVRowString, DSVRowAny } from '../d3-dsv';

--- a/src/d3-scale/index.d.ts
+++ b/src/d3-scale/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-scale module 1.0.1
 // Project: https://github.com/d3/d3-scale/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { CountableTimeInterval, TimeInterval } from '../d3-time';

--- a/src/d3-selection/index.d.ts
+++ b/src/d3-selection/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-selection module 1.0.0
 // Project: https://github.com/d3/d3-selection/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // --------------------------------------------------------------------------

--- a/src/d3-shape/index.d.ts
+++ b/src/d3-shape/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-shape module 1.0.0
 // Project: https://github.com/d3/d3-shape/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // -----------------------------------------------------------------------------------

--- a/src/d3-time-format/index.d.ts
+++ b/src/d3-time-format/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for d3JS d3-time-format module 2.0.0
 // Project: https://github.com/d3/d3-time-format/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/src/d3-time/index.d.ts
+++ b/src/d3-time/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-time module 1.0.0
 // Project: https://github.com/d3/d3-time/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // ---------------------------------------------------------------

--- a/src/d3-timer/index.d.ts
+++ b/src/d3-timer/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for d3JS d3-timer module 1.0.1
 // Project: https://github.com/d3/d3-timer/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /**

--- a/src/d3-transition/index.d.ts
+++ b/src/d3-transition/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-transition module 1.0.0
 // Project: https://github.com/d3/d3-transition/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { ArrayLike, BaseType, Selection, ValueFn } from '../d3-selection';

--- a/src/d3-voronoi/index.d.ts
+++ b/src/d3-voronoi/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-voronoi module 1.0.1
 // Project: https://github.com/d3/d3-voronoi/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 // --------------------------------------------------------------------------

--- a/src/d3-zoom/index.d.ts
+++ b/src/d3-zoom/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for d3JS d3-zoom module 1.0.2
 // Project: https://github.com/d3/d3-zoom/
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 import { ArrayLike, Selection, TransitionLike, ValueFn } from '../d3-selection';

--- a/src/d3/index.d.ts
+++ b/src/d3/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3 standard bundle 4.1.1
 // Project: https://github.com/d3/d3
-// Definitions by: Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>, Tom Wanzek <https://github.com/tomwanzek>
+// Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 export as namespace d3;


### PR DESCRIPTION
- set primary author of new version 4 definitions by module. All contributors are credited based on Definitions By comment on @types npm page for the respective module. This only affects one package.json field.
