### PR TITLE
d3-force

### DIFF
--- a/src/d3-force/index.d.ts
+++ b/src/d3-force/index.d.ts
@@ -46,7 +46,7 @@ export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum ext
     alphaTarget(target: number): this;
     velocityDecay(): number;
     velocityDecay(decay: number): this;
-    force(name: string): Force<NodeDatum, LinkDatum>; // force names are arbitrary, so return type inference is not possible
+    force<F extends Force<NodeDatum, LinkDatum>>(name: string): F; // force names are arbitrary, so return type inference is not possible
     force(name: string, force: null): this;
     force(name: string, force: Force<NodeDatum, LinkDatum>): this;
     find(x: number, y: number, radius?: number): NodeDatum | undefined;
@@ -65,7 +65,7 @@ export function forceSimulation<NodeDatum extends SimulationNodeDatum, LinkDatum
 
 export interface Force<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> {
     (alpha: number): void;
-    initialize(nodes: Array<NodeDatum>): void;
+    initialize?(nodes: Array<NodeDatum>): void;
 }
 
 

--- a/tests/d3-force/d3-force-test.ts
+++ b/tests/d3-force/d3-force-test.ts
@@ -452,22 +452,26 @@ nodeLinkSimulation
 
 let f: d3Force.Force<SimNode, SimLink>;
 
+// getter with generic force returned
+
 f = nodeLinkSimulation.force('charge');
 f = nodeLinkSimulation.force('link');
 
+
+// getter with force type cast to improve return type specificity
+
 let fLink: d3Force.ForceLink<SimNode, SimLink>;
 
-// fLink = nodeLinkSimulation.force('link'); // fails, as ForceLink specific properties are missing from 'generic' force
-
 // Need explicit, careful type casting to a specific force type
-fLink = <d3Force.ForceLink<SimNode, SimLink>>nodeLinkSimulation.force('link');
+fLink = nodeLinkSimulation.force<d3Force.ForceLink<SimNode, SimLink>>('link');
 
 // This is mainly an issue for ForceLinks, if once wants to get the links from an initialized force
 // or re-set new links for an initialized force, e.g.:
 
-simLinks = (<d3Force.ForceLink<SimNode, SimLink>>nodeLinkSimulation.force('link')).links();
+simLinks = nodeLinkSimulation.force<d3Force.ForceLink<SimNode, SimLink>>('link').links();
 
-// The same could be followed for custom  forces.
+// fLink = nodeLinkSimulation.force('link'); // fails, as ForceLink specific properties are missing from 'generic' force
+
 
 // on() --------------------------------------------------------------------------------
 


### PR DESCRIPTION
- Force<...>.initialize(...) is optional. Fixes #94.
- Improved type casting when using Simulation<...>.force<...>(...) to get a registered force. Updated related force getter tests.
