### PR TITLE
d3-axis

### DIFF
--- a/src/d3-axis/index.d.ts
+++ b/src/d3-axis/index.d.ts
@@ -66,7 +66,7 @@ export interface Axis<Domain> {
     /**
      * Gets the current scale underlying the axis.
      */
-    scale(): AxisScale<Domain>;
+    scale<A extends AxisScale<Domain>>(): A;
 
     /**
      * Sets the scale and returns the axis.

--- a/tests/d3-axis/d3-axis-test.ts
+++ b/tests/d3-axis/d3-axis-test.ts
@@ -13,6 +13,7 @@ import {
     scaleOrdinal,
     ScaleOrdinal,
     scalePow,
+    ScalePower,
     scaleTime,
     ScaleTime,
 } from '../../src/d3-scale';
@@ -70,11 +71,17 @@ let leftAxis: d3Axis.Axis<number | { valueOf(): number }> = d3Axis.axisLeft(scal
 // scale(...) ----------------------------------------------------------------
 
 leftAxis = leftAxis.scale(scalePow());
+let powerScale: ScalePower<number, number> = leftAxis.scale<ScalePower<number, number>>();
+// powerScale = leftAxis.scale(); // fails, without casting as AxisScale is purposely  generic
 
+
+
+bottomAxis = bottomAxis.scale(scaleOrdinal<number>());
 // bottomAxis = bottomAxis.scale(scalePow()) // fails, domain of scale incompatible with domain of axis
 
 let axisScale: d3Axis.AxisScale<string> = bottomAxis.scale();
-// let ordinalScale: ScaleOrdinal<string, number> = bottomAxis.scale(); // fails, without casting as AxisScale is purposely  generic
+let ordinalScale: ScaleOrdinal<string, number> = bottomAxis.scale<ScaleOrdinal<string, number>>();
+// ordinalScale = bottomAxis.scale(); // fails, without casting as AxisScale is purposely  generic
 
 // ticks(...) ----------------------------------------------------------------
 


### PR DESCRIPTION
- Templated Axis<Domain>.scale<...>() getter, so that returned can be  cast upon retrieval for improved specificity over the fallback AxisScale<Domain> minimal interface. Updated related tests.
