### PR TITLE
Follow-up d3-selection d3-selection-multi d3-interpolate

### DIFF
--- a/src/d3-interpolate/index.d.ts
+++ b/src/d3-interpolate/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import { ColorCommonInstance, RGBColor } from '../d3-color';
+import { ColorCommonInstance } from '../d3-color';
 
 
 // --------------------------------------------------------------------------

--- a/src/d3-selection/index.d.ts
+++ b/src/d3-selection/index.d.ts
@@ -12,7 +12,7 @@
  * without 'd3-selection' trying to use properties internally which would otherwise not
  * be supported.
  */
-export type BaseType = Element | EnterElement;
+export type BaseType = Element | EnterElement | Window;
 // export type BaseType = any; // Alternative, very permissive BaseType specification for edge cases
 
 export interface ArrayLike<T> {

--- a/tests/d3-selection-multi/d3-selection-multi-test.ts
+++ b/tests/d3-selection-multi/d3-selection-multi-test.ts
@@ -7,10 +7,10 @@
  * are not intended as functional tests.
  */
 
-import {Selection} from '../../src/d3-selection';
-import {Transition} from '../../src/d3-transition';
+import { Selection, ArrayLike } from '../../src/d3-selection';
+import { Transition } from '../../src/d3-transition';
 
-import '../../src/d3-selection-multi';
+import * as d3SelectionMulti from '../../src/d3-selection-multi';
 
 let selection: Selection<HTMLAnchorElement, string, null, undefined>;
 
@@ -149,3 +149,50 @@ transition = transition.styles(function (d) {
 transition = transition.styles(function (d) {
     return this.id ? { color: 'red' } : { color: d };
 }, 'important');
+
+// Test ValueMap interface ----------------------------------------------
+
+interface SampleDatum {
+    name: string;
+    r: number;
+    filled: boolean;
+}
+
+let valueMap: d3SelectionMulti.ValueMap<SVGCircleElement, SampleDatum>;
+
+valueMap = {
+    foo1: 'test',
+    foo2: 2,
+    foo3: true,
+    foo4: null,
+    bar1: function (d) {
+        let that: SVGCircleElement = this;
+        let datum: SampleDatum = d;
+        return d.name;
+    },
+    bar2: function (d, i) {
+        let that: SVGCircleElement = this;
+        let datum: SampleDatum = d;
+        let index: number =  i;
+        return d.r;
+    },
+    bar3: function (d, i, g) {
+        let that: SVGCircleElement = this;
+        let datum: SampleDatum = d;
+        let index: number = i;
+        let group: Array<SVGCircleElement> | ArrayLike<SVGCircleElement> = g;
+        return d.filled;
+    }
+};
+
+// valueMap = { // fails, as an array is not a permissible value type
+//     foo1: [1, 2]
+// };
+
+// valueMap = { // fails, as a ValueFunction returning an array is not a permissible value type
+//     foo1: function (d) {
+//         let that: SVGCircleElement = this;
+//         let datum: SampleDatum = d;
+//         return [1, 2];
+//     }
+// };

--- a/tests/d3-selection/d3-selection-test.ts
+++ b/tests/d3-selection/d3-selection-test.ts
@@ -1,7 +1,7 @@
 
 /**
  * Typescript definition tests for d3/d3-selection module
- * 
+ *
  * Note: These tests are intended to test the definitions only
  * in the sense of typing and call signature consistency. They
  * are not intended as functional tests.
@@ -89,10 +89,9 @@ let body4: d3Selection.Selection<HTMLBodyElement, BodyDatum, null, undefined> = 
 // d3Selection.select<HTMLBodyElement, BodyDatum>(baseTypeEl.node()); // fails as baseTypeEl.node() is not of type HTMLBodyElement
 
 
-// TODO: The below are related to github issue #2 (BaseType choice)
 
 d3Selection.select(xDoc);
-// d3Selection.select(xWindow); // Window cannot does not match type BaseType = Element | EnterElement
+d3Selection.select(xWindow);
 
 
 // test top-level selectAll() -------------------------------------------------------------
@@ -154,7 +153,7 @@ let documentLinks: d3Selection.Selection<HTMLAnchorElement | HTMLAreaElement, an
 // Expected: datum propagates down from selected element to sub-selected descendant element
 // Parent element and Parent Datum of sub-selected element is the same as starting selection
 
-// Using select(...) sub-selection with a string argument. 
+// Using select(...) sub-selection with a string argument.
 
 let svgEl: d3Selection.Selection<SVGSVGElement, SVGDatum, HTMLElement, any> = d3Selection.select<SVGSVGElement, SVGDatum>('svg');
 
@@ -375,7 +374,7 @@ circles = circles
     .property('__hitchhikersguide__', {
         value: 42,
         survival: 'towel'
-    }); // any 
+    }); // any
 
 circles = circles
     .property('__hitchhikersguide__', function (d, i, group) {
@@ -542,7 +541,7 @@ circles2 = d3Selection.select<SVGSVGElement, any>('#svg2')
 circles2 = circles2 // returned update selection has the same type parameters as original selection, if data type is unchanged
     .data<CircleDatumAlternative>(endCircleData, function (d) { return d.nodeId; });
 
-// circles2.data<DivDatum>(endCircleData, function (d) { return d.nodeId; }); // fails, forced data type parameter and data argument mismatch 
+// circles2.data<DivDatum>(endCircleData, function (d) { return d.nodeId; }); // fails, forced data type parameter and data argument mismatch
 
 // ENTER-selection -----------------------------------------------------------------
 
@@ -612,7 +611,7 @@ tr = d3Selection.select('body')
     // .data<number[]>([{test: 1}, {test: 2}]) // fails, using this data statement instead, would fail because of its type parameter not being met by input
     .enter().append<HTMLTableRowElement>('tr');
 
-nMatrix = tr.data(); // i.e. matrix 
+nMatrix = tr.data(); // i.e. matrix
 
 let td: d3Selection.Selection<HTMLTableDataCellElement, number, HTMLTableRowElement, number[]>;
 td = tr.selectAll()
@@ -633,7 +632,7 @@ let tr2 = d3Selection.select('body')
     .data(matrix)
     .enter().append('tr');
 
-nMatrix = tr2.data(); // i.e. matrix 
+nMatrix = tr2.data(); // i.e. matrix
 
 let td2 = tr2.selectAll('td')
     .data(function (d) { return d; }) // d : Array<number> inferred (Array[4] of number per parent <tr>)
@@ -773,7 +772,7 @@ function enforceMinRadius(selection: d3Selection.Selection<SVGCircleElement, Cir
 }
 
 // returns 'this' selection
-circles = circles.call(enforceMinRadius, 40); // check chaining return type by re-assigning 
+circles = circles.call(enforceMinRadius, 40); // check chaining return type by re-assigning
 
 // circles.call(function (selection: d3Selection.Selection<HTMLDivElement, CircleDatum, any, any>):void {
 //     // fails, group element types of selection not compatible: SVGCircleElement v HTMLDivElement


### PR DESCRIPTION
- d3-selection: Added `Window` to union type alias `BaseType`. Uncommented related test. This is related to the BaseType choice issue #2 
- d3-selection-multi: Tests only: Changed import statement from side-efffects only to alias import. Added tests for ValueMap interface. Fixes #99.
- d3-interpolate: Remove unnecessary import of RGBColor.
