### PR TITLE
Add type parameter to `local` in `d3-selection` module

### DIFF
--- a/src/d3-selection/index.d.ts
+++ b/src/d3-selection/index.d.ts
@@ -134,7 +134,7 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
      *
      * @param name The `d3.local` variable to look up.
      */
-    property<T>(name: Local<T>): T;
+    property<T>(name: Local<T>): T | undefined;
     property(name: string, value: ValueFn<GElement, Datum, any>): this;
     property(name: string, value: null): this;
     property(name: string, value: any): this;
@@ -283,7 +283,7 @@ export function touches(container: ContainerElement, touches?: TouchList): Array
 
 
 export interface Local<T> {
-    get(node: Element): T;
+    get(node: Element): T | undefined;
     remove(node: Element): boolean;
     set(node: Element, value: T): Element;
     /**

--- a/src/d3-selection/index.d.ts
+++ b/src/d3-selection/index.d.ts
@@ -129,11 +129,28 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     style(name: string, value: ValueFn<GElement, Datum, string | number | boolean>, priority?: null | 'important'): this;
 
     property(name: string): any;
+    /**
+     * Look up a local variable on the first node of this selection. Note that this is not equivalent to `local.get(selection.node())` in that it will not look up locals set on the parent node(s).
+     *
+     * @param name The `d3.local` variable to look up.
+     */
     property<T>(name: Local<T>): T;
     property(name: string, value: ValueFn<GElement, Datum, any>): this;
     property(name: string, value: null): this;
     property(name: string, value: any): this;
+    /**
+     * Store a value in a `d3.local` variable. This is equivalent to `selection.each(function (d, i, g) { name.set(this, value.call(this, d, i, g)); })` but more concise.
+     *
+     * @param name A `d3.local` variable
+     * @param value A callback that returns the value to store
+     */
     property<T>(name: Local<T>, value: ValueFn<GElement, Datum, T>): this;
+    /**
+     * Store a value in a `d3.local` variable for each node in the selection. This is equivalent to `selection.each(function () { name.set(this, value); })` but more concise.
+     *
+     * @param name A `d3.local` variable
+     * @param value A callback that returns the value to store
+     */
     property<T>(name: Local<T>, value: T): this;
 
     text(): string;

--- a/src/d3-selection/index.d.ts
+++ b/src/d3-selection/index.d.ts
@@ -129,9 +129,12 @@ interface Selection<GElement extends BaseType, Datum, PElement extends BaseType,
     style(name: string, value: ValueFn<GElement, Datum, string | number | boolean>, priority?: null | 'important'): this;
 
     property(name: string): any;
+    property<T>(name: Local<T>): T;
     property(name: string, value: ValueFn<GElement, Datum, any>): this;
     property(name: string, value: null): this;
     property(name: string, value: any): this;
+    property<T>(name: Local<T>, value: ValueFn<GElement, Datum, T>): this;
+    property<T>(name: Local<T>, value: T): this;
 
     text(): string;
     text(value: string | number | boolean): this;
@@ -262,10 +265,10 @@ export function touches(container: ContainerElement, touches?: TouchList): Array
 // ---------------------------------------------------------------------------
 
 
-export interface Local {
-    get(node: Element): any;
+export interface Local<T> {
+    get(node: Element): T;
     remove(node: Element): boolean;
-    set(node: Element, value: any): Element;
+    set(node: Element, value: T): Element;
     /**
      * Obtain a string with the internally assigned property name for the local
      * which is used to store the value on a node
@@ -276,7 +279,7 @@ export interface Local {
 /**
  * Obtain a new local variable
  */
-export function local(): Local;
+export function local<T>(): Local<T>;
 
 // ---------------------------------------------------------------------------
 // namespace.js related

--- a/src/d3-selection/index.d.ts
+++ b/src/d3-selection/index.d.ts
@@ -283,8 +283,17 @@ export function touches(container: ContainerElement, touches?: TouchList): Array
 
 
 export interface Local<T> {
+    /**
+     * Retrieves a local variable stored on the node (or one of its parents).
+     */
     get(node: Element): T | undefined;
+    /**
+     *
+     */
     remove(node: Element): boolean;
+    /**
+     * Store a value for this local variable. Calling `.get()` on children of this node will also retrieve the variable's value.
+     */
     set(node: Element, value: T): Element;
     /**
      * Obtain a string with the internally assigned property name for the local

--- a/tests/d3-selection/d3-selection-test.ts
+++ b/tests/d3-selection/d3-selection-test.ts
@@ -895,14 +895,20 @@ positions = d3Selection.touches(h, changedTouches);
 // ---------------------------------------------------------------------------------------
 
 let xElement: Element;
-let foo: d3Selection.Local = d3Selection.local();
+let foo: d3Selection.Local<number[]> = d3Selection.local<number[]>();
 let propName: string = foo.toString();
 
-console.log('Local Property Name: %s', propName);
+// direct set & get on Local<T> object
+xElement = foo.set(xElement, [1, 2, 3]);
+let array: number[] = foo.get(xElement);
 
-xElement = foo.set(xElement, 'test');
+// test read & write of .property() access to locals
+array = d3Selection.select(xElement)
+  .property(foo, [3, 2, 1])
+  .property(foo, () => [999])
+  .property(foo);
 
-// TODO: complete remaing tests for Local
+foo.remove(xElement);
 
 // ---------------------------------------------------------------------------------------
 // Tests of Namespace


### PR DESCRIPTION
Since `d3.local()` creates an object that acts kind of like a `Map<Element, T>`, it seems wisest to add a type parameter in order for the compiler to track the type of data stored.

This PR also adds a few conveniences around the use of `Selection.property`, hinted at by the [documentation](https://github.com/d3/d3-selection#local):

> If you are just setting a single variable, consider using [selection.property](https://github.com/d3/d3-selection#selection_property):
> 
> ``` javascript
> selection.property(foo, function(d) { return d.value; });
> ```

I played around with it in the console and it does indeed work well:

``` javascript
> let local = d3.local(), p = d3.select('p');
> local.set(p.node(), [1, 2, 3]);
> local.get(p.node());
[1, 2, 3]
> p.property(local, [4, 5, 6]);
> p.property(local);
[4, 5, 6]
> local.get(p.node());
[4, 5, 6]
```

I've added to the tests to cover this as well as `Local.remove`, which was missing from the original test suite.
