### PR TITLE
d3-shape and d3-geo

### DIFF
--- a/src/d3-geo/index.d.ts
+++ b/src/d3-geo/index.d.ts
@@ -1,6 +1,6 @@
 // Type definitions for D3JS d3-geo module 1.2.0
 // Project: https://github.com/d3/d3-geo/
-// Definitions by: Hugues Stefanski <https://github.com/Ledragon>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
+// Definitions by: Hugues Stefanski <https://github.com/Ledragon>, Tom Wanzek <https://github.com/tomwanzek>, Alex Ford <https://github.com/gustavderdrache>, Boris Yankov <https://github.com/borisyankov>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
 /// <reference types="geojson" />

--- a/src/d3-shape/index.d.ts
+++ b/src/d3-shape/index.d.ts
@@ -276,7 +276,7 @@ export var curveNatural: CurveFactory;
 
 export var curveStep: CurveFactory;
 
-export var stepAfter: CurveFactory;
+export var curveStepAfter: CurveFactory;
 
 export var curveStepBefore: CurveFactory;
 

--- a/tests/d3-shape/d3-shape-test.ts
+++ b/tests/d3-shape/d3-shape-test.ts
@@ -855,7 +855,7 @@ curveFactory = d3Shape.curveNatural;
 
 curveFactory = d3Shape.curveStep;
 
-curveFactory = d3Shape.stepAfter;
+curveFactory = d3Shape.curveStepAfter;
 
 curveFactory = d3Shape.curveStepBefore;
 


### PR DESCRIPTION
- d3-shape: Fix bug in predefined curve factory naming: curveStepAfter (This bug was identified and already fixed on `DefinitelyTyped/types-2.0` by @Tragetaschen (Besten Dank!) The edit here will be made to keep this repo in synch until its retirement, when the migration to DT/@types is complete.
- d3-geo: Added to definitions authors for future support
