### PR TITLE
d3-voronoi and d3-shape point-type interfaces

### DIFF
--- a/src/d3-shape/index.d.ts
+++ b/src/d3-shape/index.d.ts
@@ -326,10 +326,12 @@ export var symbolWye: SymbolType;
 // -----------------------------------------------------------------------------------
 
 
-// HACK: SeriesPoint is a [number, number] two-element Array with added
+// SeriesPoint is a [number, number] two-element Array with added
 // data and index properties related to the data element which formed the basis for the
 // SeriesPoint
 export interface SeriesPoint<Datum> extends Array<number> {
+    0: number;
+    1: number;
     index: number;
     data: Datum;
 }

--- a/src/d3-voronoi/index.d.ts
+++ b/src/d3-voronoi/index.d.ts
@@ -9,18 +9,24 @@
 
 
 /**
- * The Point type is defined as a cue that the array is strictly of type [number, number] with two elements
+ * The VoronoiPoint interface is defined as a cue that the array is strictly of type [number, number] with two elements
  * for x and y coordinates. However, it is used as a base for interface definitions, and [number, number]
  * cannot be extended.
  */
-export type VoronoiPoint = Array<number>;
+export interface VoronoiPoint extends Array<number> {
+    0: number;
+    1: number;
+}
 
 /**
- * The PointPair type is defined as a cue that the array is strictly of type [[number, number], [number, number]] with two elements, one
+ * The VoronoiPointPair interface is defined as a cue that the array is strictly of type [[number, number], [number, number]] with two elements, one
  * for each point containing the respective x and y coordinates. However, it is used as a base for interface definitions, and
- * [[number, number], [number, number]]cannot be extended.
+ * [[number, number], [number, number]] cannot be extended.
  */
-export type VoronoiPointPair = Array<[number, number]> // [Point, Point];
+export interface VoronoiPointPair extends Array<[number, number]> {
+    0: [number, number];
+    1: [number, number];
+}
 
 export interface VoronoiPolygon<T> extends Array<[number, number]> {
     data: T;

--- a/tests/d3-voronoi/d3-voronoi-test.ts
+++ b/tests/d3-voronoi/d3-voronoi-test.ts
@@ -65,6 +65,9 @@ let point: d3Voronoi.VoronoiPoint;
 point[0] = 10; // x-coordinate
 point[1] = 10; // y-coordinate
 
+point = [10, 10];
+// point = [10]; // fails, second element for y-coordinate missing
+// point = ['a', 'b']; // fails, wrong element type
 
 // VoronoiPointPair ---------------------------------------------------
 
@@ -74,6 +77,13 @@ pointPair[0][0] = 10; // x-coordinate of first point
 pointPair[0][1] = 10; // y-coordinate of first point
 pointPair[1][0] = 20; // x-coordinate of second point
 pointPair[1][1] = 10; // y-coordinate of second point
+
+pointPair = [[10, 10], [50, 50]];
+
+// pointPair = [[10, 10]]; // fails, second point coordinates missing
+// pointPair = [[10, 10], [50]]; // fails, one element is not of type [number, number]
+// pointPair = [[10], [50, 50]]; // fails, one element is not of type [number, number]
+// pointPair = [['a', 10], [50, 50]]; // fails, one element is not of type [number, number]
 
 // VoronoiPolygon -------------------------------------------------------
 


### PR DESCRIPTION
- d3-voronoi: Changed type aliases VoronoiPoint and VoronoiPointPair to interfaces and added mandatory elements for 0 and 1 indices. Thanks for this suggestion @gustavderdrache .
- d3-shape: Added mandatory element  for 0 and 1 indices to `SeriesPoint` interface (same rationale as above)
- Fixes #108.
