### PR TITLE
d3-transition

### DIFF
--- a/src/d3-transition/index.d.ts
+++ b/src/d3-transition/index.d.ts
@@ -12,7 +12,7 @@ declare module '../d3-selection' {
     export interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
         interrupt(name?: string): Transition<GElement, Datum, PElement, PDatum>;
         transition(name?: string): Transition<GElement, Datum, PElement, PDatum>;
-        transition(transition: Transition<GElement, Datum, PElement, PDatum>): Transition<GElement, Datum, PElement, PDatum>;
+        transition(transition: Transition<BaseType, any, any, any>): Transition<GElement, Datum, PElement, PDatum>;
     }
 }
 

--- a/tests/d3-transition/d3-transition-test.ts
+++ b/tests/d3-transition/d3-transition-test.ts
@@ -103,12 +103,13 @@ exitTransition = exitCircles.transition('exit');
 let newEnterTransition: d3Transition.Transition<SVGCircleElement, CircleDatum, SVGSVGElement, SVGDatum>;
 newEnterTransition = enterCircles.transition(enterTransition);
 
-let wrongElementTypeTransition: d3Transition.Transition<HTMLDivElement, CircleDatum, HTMLBodyElement, any>;
-let wrongDatumTypeTransition: d3Transition.Transition<SVGCircleElement, { wrong: string }, SVGSVGElement, any>;
+let differentElementTypeTransition: d3Transition.Transition<SVGSVGElement, CircleDatum, HTMLBodyElement, any>;
+let differentDatumTypeTransition: d3Transition.Transition<SVGCircleElement, { differrent: string }, SVGSVGElement, any>;
 
-newEnterTransition = enterCircles.transition(enterTransition);
-// newEnterTransition = enterCircles.transition(wrongElementTypeTransition);// fails, wrong group element type
-// newEnterTransition = enterCircles.transition(wrongDatumTypeTransition);// fails, wrong datum type
+// Comparable use cases arise e.g. when using an existing transition to generate a new transition
+// on a different selection to synchronize them (see e.g. Mike Bostock's Brush & Zoom II Example https://bl.ocks.org/mbostock/f48fcdb929a620ed97877e4678ab15e6)
+newEnterTransition = enterCircles.transition(differentElementTypeTransition);
+newEnterTransition = enterCircles.transition(differentDatumTypeTransition);
 
 // --------------------------------------------------------------------------
 // Test Transition Configuration (Timing)


### PR DESCRIPTION
- Relax constraint of existing transition type which can be used to generate a transition on a selection. This allows to inherit e.g. timing from another transition. Updated Tests. Fixes #110.
