### PR TITLE
add null/undefined union types to definitions for strict null checking

### DIFF
--- a/src/d3-force/index.d.ts
+++ b/src/d3-force/index.d.ts
@@ -30,7 +30,7 @@ export interface SimulationLinkDatum<NodeDatum extends SimulationNodeDatum> {
     index?: number;
 }
 
-export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> {
+export interface Simulation<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum> | undefined> {
     restart(): this;
     stop(): this;
     tick(): void;
@@ -63,7 +63,7 @@ export function forceSimulation<NodeDatum extends SimulationNodeDatum, LinkDatum
 // ----------------------------------------------------------------------
 
 
-export interface Force<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum>> {
+export interface Force<NodeDatum extends SimulationNodeDatum, LinkDatum extends SimulationLinkDatum<NodeDatum> | undefined> {
     (alpha: number): void;
     initialize?(nodes: Array<NodeDatum>): void;
 }

--- a/src/d3-selection-multi/index.d.ts
+++ b/src/d3-selection-multi/index.d.ts
@@ -11,7 +11,7 @@ import {Transition} from '../d3-transition';
 export type ValueMap<Element, Datum> = { [key: string]: number | string | boolean | null | ValueFn<Element, Datum, number | string | boolean | null> };
 
 declare module '../d3-selection' {
-    export interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
+    export interface Selection<GElement extends BaseType | null, Datum, PElement extends BaseType | null, PDatum> {
         /**
          * Set multiple attributes on the given selection. Attribute values may be constant or derived from each node and its bound data.
          *
@@ -59,7 +59,7 @@ declare module '../d3-selection' {
 }
 
 declare module '../d3-transition' {
-    export interface Transition<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
+    export interface Transition<GElement extends BaseType | null, Datum, PElement extends BaseType | null, PDatum> {
         /**
          * Set multiple attribute values. The transition will animate from the present value to the new value. Attribute values may be constant or derived from each node and its bound data.
          *

--- a/src/d3-selection/index.d.ts
+++ b/src/d3-selection/index.d.ts
@@ -99,7 +99,7 @@ export function selectAll<GElement extends BaseType, OldDatum>(nodes: ArrayLike<
 
 
 
-interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
+interface Selection<GElement extends BaseType | null, Datum, PElement extends BaseType | null, PDatum> {
 
     // Sub-selection -------------------------
 

--- a/src/d3-transition/index.d.ts
+++ b/src/d3-transition/index.d.ts
@@ -9,7 +9,7 @@ import { ArrayLike, BaseType, Selection, ValueFn } from '../d3-selection';
  * Extend interface 'Selection' by declaration merging with 'd3-selection'
  */
 declare module '../d3-selection' {
-    export interface Selection<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
+    export interface Selection<GElement extends BaseType | null, Datum, PElement extends BaseType | null, PDatum> {
         interrupt(name?: string): Transition<GElement, Datum, PElement, PDatum>;
         transition(name?: string): Transition<GElement, Datum, PElement, PDatum>;
         transition(transition: Transition<BaseType, any, any, any>): Transition<GElement, Datum, PElement, PDatum>;
@@ -21,7 +21,7 @@ export function active<GElement extends BaseType, Datum, PElement extends BaseTy
 
 export function interrupt(node: BaseType, name?: string): void;
 
-export interface Transition<GElement extends BaseType, Datum, PElement extends BaseType, PDatum> {
+export interface Transition<GElement extends BaseType | null, Datum, PElement extends BaseType | null, PDatum> {
 
     // Sub-selection -------------------------
 


### PR DESCRIPTION
I want to use the d3 v4 definitions (thank you very much for doing them BTW) in a project that has `--strictNullChecks` enabled. At certain points, the d3 definitions themselves made references to `null`s and `undefined`s that caused errors in this mode. This PR adds the required `null`/`undefined` union types to the d3 definitions that make these errors go away (but don't affect usage in any way in non strict null checking mode).

What is not in this PR are any tests to make sure that compilation under `--strictNullChecks` succeeds. I tried to fiddle around with the Gruntfile a bit to create such, but for some reason changing the `strictNullChecks` option there to `true` there did nothing, so in the end I just abandoned the effort altogether.
