### PR TITLE
Allow arbitrary group and thousands string separator

### DIFF
--- a/src/d3-format/index.d.ts
+++ b/src/d3-format/index.d.ts
@@ -10,12 +10,12 @@ export interface FormatLocaleDefinition {
     /**
      * The decimal point (e.g., ".")
      */
-    decimal: '.' | ',';
+    decimal: string;
     /**
      * The group separator (e.g., ","). Note that the thousands property is a misnomer, as\
      * the grouping definition allows groups other than thousands.
      */
-    thousands: '.' | ',';
+    thousands: string;
     /**
      * The array of group sizes (e.g., [3]), cycled as needed.
      */

--- a/tests/d3-format/d3-format-test.ts
+++ b/tests/d3-format/d3-format-test.ts
@@ -63,8 +63,8 @@ num = d3Format.precisionRound(0.0005, 3000);
 // Test Locale Definition
 // ----------------------------------------------------------------------
 
-let decimal: '.' | ',' = localeDef.decimal;
-let thousands: '.' | ',' = localeDef.thousands;
+let decimal: string = localeDef.decimal;
+let thousands: string = localeDef.thousands;
 let grouping: Array<number> = localeDef.grouping;
 let currency: [string, string] = localeDef.currency;
 


### PR DESCRIPTION
Separators should not be limited to `'.' | ','`

Most of Europe uses space separator. I would expect there are countries with completely different separators.
